### PR TITLE
Transformer suffix added to transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ flow.log_prob(x)
 The package currently supports the following:
 
 - Supports both `CouplingFlow` ([Dinh et al., 2017](https://arxiv.org/abs/1605.08803)) and `MaskedAutoregressiveFlow` ([Papamakarios et al., 2017](https://arxiv.org/abs/1705.07057v4))  architectures
-- Supports common transformers, such as `Affine` and `RationalQuadraticSpline` (the latter used in neural spline flows; [Durkan et al., 2019](https://arxiv.org/abs/1906.04032))
+- Supports common transformers, such as `AffineTransformer` and `RationalQuadraticSplineTransformer` (the latter used in neural spline flows; [Durkan et al., 2019](https://arxiv.org/abs/1906.04032))
 - `BlockNeuralAutoregressiveFlow`, as introduced by [De Cao et al., 2019](https://arxiv.org/abs/1904.04676)
 
 For more detailed examples, see [examples](https://github.com/danielward27/flowjax/blob/main/examples/).

--- a/examples/conditional.ipynb
+++ b/examples/conditional.ipynb
@@ -10,7 +10,7 @@
                 "$$\\mu \\sim \\text{Uniform}(-2, 2)$$\n",
                 "$$x_i \\sim N(\\mu, 1) \\quad \\text{for}\\ i\\ \\text{in}\\ 1,2$$\n",
                 "\n",
-                "We will try to infer the conditional distribution $p(x|\\mu)$ using a conditional normalizing flow. For more examples of architectures, see unconditional_examples.ipynb. Here, we will use a `RationalQuadraticSpline` bijection with a `CouplingFlow` architecture.\n"
+                "We will try to infer the conditional distribution $p(x|\\mu)$ using a conditional normalizing flow. For more examples of architectures, see unconditional_examples.ipynb. Here, we will use a `RationalQuadraticSplineTransformer` bijection with a `CouplingFlow` architecture.\n"
             ]
         },
         {
@@ -22,7 +22,7 @@
                 "from jax import random\n",
                 "import jax.numpy as jnp\n",
                 "from flowjax.flows import CouplingFlow\n",
-                "from flowjax.bijections.transformers import RationalQuadraticSpline\n",
+                "from flowjax.bijections.transformers import RationalQuadraticSplineTransformer\n",
                 "from flowjax.distributions import Normal\n",
                 "from flowjax.train_utils import train_flow\n",
                 "import matplotlib.pyplot as plt"
@@ -80,7 +80,7 @@
                 "flow = CouplingFlow(\n",
                 "    key=subkey,\n",
                 "    base_dist=Normal(x.shape[1]),\n",
-                "    transformer=RationalQuadraticSpline(K=8, B=3), # 8 spline segments.\n",
+                "    transformer=RationalQuadraticSplineTransformer(K=8, B=3), # 8 spline segments.\n",
                 "    cond_dim=cond.shape[1]\n",
                 "    )\n",
                 "\n",

--- a/examples/unconditional.ipynb
+++ b/examples/unconditional.ipynb
@@ -25,7 +25,7 @@
                 "import jax.numpy as jnp\n",
                 "from jax import random\n",
                 "from flowjax.flows import CouplingFlow, MaskedAutoregressiveFlow\n",
-                "from flowjax.bijections.transformers import Affine, RationalQuadraticSpline\n",
+                "from flowjax.bijections.transformers import AffineTransformer, RationalQuadraticSplineTransformer\n",
                 "from flowjax.train_utils import train_flow\n",
                 "from flowjax.distributions import Normal\n",
                 "import matplotlib.pyplot as plt\n",
@@ -87,7 +87,7 @@
             "metadata": {},
             "source": [
                 "### Create flows\n",
-                "Here we show how to create flows with two of the most common architectures, coupling flows (see e.g. [RealNVP](https://arxiv.org/abs/1605.08803)), and [masked autoregressive flows](https://arxiv.org/abs/1705.07057). Here we use `Affine` and [`RationalQuadraticSpline`](https://arxiv.org/abs/1906.04032) transformers."
+                "Here we show how to create flows with two of the most common architectures, coupling flows (see e.g. [RealNVP](https://arxiv.org/abs/1605.08803)), and [masked autoregressive flows](https://arxiv.org/abs/1705.07057). Here we use `AffineTransformer` and [`RationalQuadraticSplineTransformer`](https://arxiv.org/abs/1906.04032) transformers."
             ]
         },
         {
@@ -100,10 +100,10 @@
                 "base_dist = Normal(x.shape[1])\n",
                 "\n",
                 "flows = {\n",
-                "    \"Affine Coupling\": CouplingFlow(flow_key, base_dist, Affine()),\n",
-                "    \"Spline Coupling\": CouplingFlow(flow_key, base_dist, RationalQuadraticSpline(K=8, B=3)),\n",
-                "    \"Affine Masked Autoregressive\": MaskedAutoregressiveFlow(flow_key, base_dist, Affine()),\n",
-                "    \"Spline Masked Autoregressive\": MaskedAutoregressiveFlow(flow_key, base_dist, RationalQuadraticSpline(K=8, B=3)),\n",
+                "    \"Affine Coupling\": CouplingFlow(flow_key, base_dist, AffineTransformer()),\n",
+                "    \"Spline Coupling\": CouplingFlow(flow_key, base_dist, RationalQuadraticSplineTransformer(K=8, B=3)),\n",
+                "    \"Affine Masked Autoregressive\": MaskedAutoregressiveFlow(flow_key, base_dist, AffineTransformer()),\n",
+                "    \"Spline Masked Autoregressive\": MaskedAutoregressiveFlow(flow_key, base_dist, RationalQuadraticSplineTransformer(K=8, B=3)),\n",
                 "}"
             ]
         },

--- a/flowjax/bijections/transformers.py
+++ b/flowjax/bijections/transformers.py
@@ -1,5 +1,6 @@
 """Contains transformers, which are bijections that have methods that facilitate
-parameterisation with neural networks.
+parameterisation with neural networks. All transformers have the "Transformer"
+suffix, to avoid potential name clashes with bijections.
 """
 
 import jax
@@ -8,7 +9,7 @@ from flowjax.bijections.abc import Transformer
 from functools import partial
 
 
-class Affine(Transformer):
+class AffineTransformer(Transformer):
     "Affine transformation compatible with neural network parameterisation."
 
     def transform(self, x, loc, scale):
@@ -34,7 +35,7 @@ class Affine(Transformer):
         return loc, jnp.exp(log_scale)
 
 
-class RationalQuadraticSpline(Transformer):
+class RationalQuadraticSplineTransformer(Transformer):
     def __init__(
         self, K, B, min_bin_width=1e-3, min_bin_height=1e-3, min_derivative=1e-3
     ):
@@ -49,7 +50,7 @@ class RationalQuadraticSpline(Transformer):
             [-B * 1e4, -B, B, B * 1e4]
         )  # Avoids jax control flow for identity tails
         """
-        RationalQuadraticSpline (https://arxiv.org/abs/1906.04032). Ouside the interval
+        RationalQuadraticSplineTransformer (https://arxiv.org/abs/1906.04032). Ouside the interval
         [-B, B], the identity transform is used. Each row of parameter matrices
         (x_pos, y_pos, derivatives) corresponds to a column in x. 
 

--- a/tests/test_bijections/test_invertibility.py
+++ b/tests/test_bijections/test_invertibility.py
@@ -3,13 +3,13 @@ from jax import random
 import jax.numpy as jnp
 from flowjax.bijections.coupling import Coupling
 from flowjax.bijections.masked_autoregressive import MaskedAutoregressive
-from flowjax.bijections.transformers import Affine
+from flowjax.bijections.transformers import AffineTransformer
 from flowjax.bijections.utils import Flip, Permute
-from flowjax.bijections.transformers import Affine, RationalQuadraticSpline
+from flowjax.bijections.transformers import AffineTransformer, RationalQuadraticSplineTransformer
 
 transformers = {
-    "Affine": Affine(),
-    "RationalQuadraticSpline": RationalQuadraticSpline(K=5, B=3),
+    "AffineTransformer": AffineTransformer(),
+    "RationalQuadraticSplineTransformer": RationalQuadraticSplineTransformer(K=5, B=3),
 }
 
 @pytest.mark.parametrize("bijection", transformers.values(), ids=transformers.keys())
@@ -44,7 +44,7 @@ bijections = {
     "Permute": Permute(jnp.flip(jnp.arange(dim))),
     "Coupling (unconditional)": Coupling(
         key,
-        Affine(),
+        AffineTransformer(),
         d=dim // 2,
         D=dim,
         cond_dim=0,
@@ -53,7 +53,7 @@ bijections = {
     ),
     "Coupling (conditional)": Coupling(
         key,
-        Affine(),
+        AffineTransformer(),
         d=dim // 2,
         D=dim,
         cond_dim=cond_dim,
@@ -61,16 +61,16 @@ bijections = {
         nn_depth=2,
     ),
     "MaskedAutoregressive_Affine (unconditional)": MaskedAutoregressive(
-        key, Affine(), cond_dim=0, dim=dim, nn_width=10, nn_depth=2
+        key, AffineTransformer(), cond_dim=0, dim=dim, nn_width=10, nn_depth=2
     ),
     "MaskedAutoregressive_Affine (conditional)": MaskedAutoregressive(
-        key, Affine(), cond_dim=cond_dim, dim=dim, nn_width=10, nn_depth=2
+        key, AffineTransformer(), cond_dim=cond_dim, dim=dim, nn_width=10, nn_depth=2
     ),
     "MaskedAutoregressive_RationalQuadraticSpline (unconditional)": MaskedAutoregressive(
-        key, RationalQuadraticSpline(5, 3), cond_dim=0, dim=dim, nn_width=10, nn_depth=2
+        key, RationalQuadraticSplineTransformer(5, 3), cond_dim=0, dim=dim, nn_width=10, nn_depth=2
     ),
     "MaskedAutoregressive_RationalQuadraticSpline (conditional)": MaskedAutoregressive(
-        key, RationalQuadraticSpline(5, 3), cond_dim=cond_dim, dim=dim, nn_width=10, nn_depth=2
+        key, RationalQuadraticSplineTransformer(5, 3), cond_dim=cond_dim, dim=dim, nn_width=10, nn_depth=2
     )
 }
 

--- a/tests/test_bijections/test_rational_quadratic_spline.py
+++ b/tests/test_bijections/test_rational_quadratic_spline.py
@@ -1,10 +1,10 @@
 import pytest
-from flowjax.bijections.transformers import RationalQuadraticSpline
+from flowjax.bijections.transformers import RationalQuadraticSplineTransformer
 from jax import random
 import jax.numpy as jnp
 
 def test_RationalQuadraticSpline_tails():
-    spline = RationalQuadraticSpline(K=5, B=3)
+    spline = RationalQuadraticSplineTransformer(K=5, B=3)
     x = jnp.array([-20, 0.1, 2, 20])
     params = random.normal(random.PRNGKey(0), (spline.num_params(x.shape[0]),))
     transform_args = spline.get_args(params)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1,5 +1,5 @@
 from flowjax.flows import CouplingFlow, BlockNeuralAutoregressiveFlow, MaskedAutoregressiveFlow
-from flowjax.bijections.transformers import Affine, RationalQuadraticSpline
+from flowjax.bijections.transformers import AffineTransformer, RationalQuadraticSplineTransformer
 from flowjax.distributions import Normal
 import jax.numpy as jnp
 from jax import random
@@ -17,10 +17,10 @@ common_kwargs = {
 
 testcases = [
     # (name, type, kwargs)}
-    ("Affine_Coupling", CouplingFlow, {"transformer": Affine()} | common_kwargs),
-    ("RationalQuadraticSpline_Coupling", CouplingFlow, {"transformer": RationalQuadraticSpline(5,3)} | common_kwargs),
+    ("Affine_Coupling", CouplingFlow, {"transformer": AffineTransformer()} | common_kwargs),
+    ("RationalQuadraticSpline_Coupling", CouplingFlow, {"transformer": RationalQuadraticSplineTransformer(5,3)} | common_kwargs),
     ("BNAF", BlockNeuralAutoregressiveFlow, {"key": random.PRNGKey(0), "base_dist": Normal(dim), "flow_layers": 2}),
-    ("Affine_MaskedAutoregessive", MaskedAutoregressiveFlow, {"transformer": Affine()} | common_kwargs)
+    ("Affine_MaskedAutoregessive", MaskedAutoregressiveFlow, {"transformer": AffineTransformer()} | common_kwargs)
 ]
 
 uncond_testcases = {n: t(**kwargs) for n, t, kwargs in testcases}


### PR DESCRIPTION
Added Transformer suffix, to avoid potential name clashes between `Bijection`s and `Transformer`s.