### PR TITLE
Fix permutation bug for 1 layer flows

### DIFF
--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -156,11 +156,11 @@ def intertwine_random_permutation(
     Returns:
         List[Bijection]: List of bijections with random permutations inbetween.
     """
-    permutations = jnp.row_stack([jnp.arange(dim) for _ in range(len(bijections) - 1)])
-    permutations = random.permutation(key, permutations, 1, True)
-
     new_bijections = []
-    for bijection, permutation in zip(bijections[:-1], permutations):
-        new_bijections.extend([bijection, Permute(permutation)])
+    for bijection in bijections[:-1]:
+        key, subkey = random.split(key)
+        perm = random.permutation(subkey, jnp.arange(dim))
+        new_bijections.extend([bijection, Permute(perm)])
+        
     new_bijections.append(bijections[-1])
     return new_bijections

--- a/tests/test_bijections/test_bijection_utils.py
+++ b/tests/test_bijections/test_bijection_utils.py
@@ -1,0 +1,30 @@
+from flowjax.bijections.utils import Flip, Permute, intertwine_flip, intertwine_random_permutation
+import pytest
+from jax import random
+import jax.numpy as jnp
+
+
+perm = jnp.array([0,1])
+test_cases = {
+    # {name: (inputs, expected)}
+    "Len 3": ([Permute(perm) for _ in range(3)], [Permute, Flip, Permute, Flip, Permute]),
+    "Len 1": ([Permute(perm)], [Permute])
+}
+
+@pytest.mark.parametrize("bijections,expected", test_cases.values(), ids=test_cases.keys())
+def test_intertwine_flip(bijections, expected):
+    "Intertwine flips (between permutation bijections)"
+    bijections = intertwine_flip(bijections)
+    assert [type(b) == ex for b, ex in zip(bijections, expected)]
+
+
+test_cases = {
+    "Len 3": ([Flip() for _ in range(3)], [Flip, Permute, Flip, Permute, Flip]),
+    "Len 1": ([Flip()], [Flip])
+}
+
+@pytest.mark.parametrize("bijections,expected", test_cases.values(), ids=test_cases.keys())
+def test_intertwine_random_permutation(bijections, expected):
+    "Intertwine permutations (between Flip bijections)"
+    bijections = intertwine_random_permutation(random.PRNGKey(0), bijections, dim=2)
+    assert [type(b) == ex for b, ex in zip(bijections, expected)]

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -43,7 +43,7 @@ def test_unconditional_flow_log_prob(flow):
     assert lp.shape == (n,)
 
     lp2 = flow.log_prob(x[0])
-    assert lp[0] == pytest.approx(lp2)
+    assert lp[0] == pytest.approx(lp2, abs=1e-5)
 
     # Test wrong dimensions raises error
     with pytest.raises(ValueError):


### PR DESCRIPTION
Prevent error for `intertwine_random_permutation` for 1 layer flows.