### PR TITLE
Flow funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Normalising flows in JAX. Training a flow can be done in a few lines of code:
 
 ```
-from flowjax.flows import BlockNeuralAutoregressiveFlow
+from flowjax.flows import block_neural_autoregressive_flow
 from flowjax.train_utils import train_flow
 from flowjax.distributions import Normal
 from jax import random
@@ -13,7 +13,7 @@ data_key, flow_key, train_key = random.split(random.PRNGKey(0), 3)
 
 x = random.uniform(data_key, (10000, 3))  # Toy data
 base_dist = Normal(3)
-flow = BlockNeuralAutoregressiveFlow(flow_key, base_dist)
+flow = block_neural_autoregressive_flow(flow_key, base_dist)
 flow, losses = train_flow(train_key, flow, x, learning_rate=0.05)
 
 # We can now evaluate the log-probability of arbitrary points
@@ -22,11 +22,11 @@ flow.log_prob(x)
 
 The package currently supports the following:
 
-- Supports both `CouplingFlow` ([Dinh et al., 2017](https://arxiv.org/abs/1605.08803)) and `MaskedAutoregressiveFlow` ([Papamakarios et al., 2017](https://arxiv.org/abs/1705.07057v4))  architectures
+- Supports both `coupling_flow` ([Dinh et al., 2017](https://arxiv.org/abs/1605.08803)) and `masked_autoregressive_flow` ([Papamakarios et al., 2017](https://arxiv.org/abs/1705.07057v4))  architectures
 - Supports common transformers, such as `AffineTransformer` and `RationalQuadraticSplineTransformer` (the latter used in neural spline flows; [Durkan et al., 2019](https://arxiv.org/abs/1906.04032))
-- `BlockNeuralAutoregressiveFlow`, as introduced by [De Cao et al., 2019](https://arxiv.org/abs/1904.04676)
+- `block_neural_autoregressive_flow`, as introduced by [De Cao et al., 2019](https://arxiv.org/abs/1904.04676)
 
-For more detailed examples, see [examples](https://github.com/danielward27/flowjax/blob/main/examples/).
+For examples of basic usage, see [examples](https://github.com/danielward27/flowjax/blob/main/examples/).
 
 ## Installation
 ```

--- a/examples/bnaf.ipynb
+++ b/examples/bnaf.ipynb
@@ -26,7 +26,7 @@
                 "from jax import random\n",
                 "import jax.numpy as jnp\n",
                 "import numpy as onp\n",
-                "from flowjax.flows import BlockNeuralAutoregressiveFlow\n",
+                "from flowjax.flows import block_neural_autoregressive_flow\n",
                 "from flowjax.distributions import Normal\n",
                 "from flowjax.train_utils import train_flow\n",
                 "import matplotlib.pyplot as plt"
@@ -74,7 +74,7 @@
             "source": [
                 "key, subkey = random.split(key)\n",
                 "\n",
-                "flow = BlockNeuralAutoregressiveFlow(\n",
+                "flow = block_neural_autoregressive_flow(\n",
                 "    key=subkey,\n",
                 "    base_dist=Normal(x.shape[1]),\n",
                 "    cond_dim=u.shape[1])\n",

--- a/examples/conditional.ipynb
+++ b/examples/conditional.ipynb
@@ -10,7 +10,7 @@
                 "$$\\mu \\sim \\text{Uniform}(-2, 2)$$\n",
                 "$$x_i \\sim N(\\mu, 1) \\quad \\text{for}\\ i\\ \\text{in}\\ 1,2$$\n",
                 "\n",
-                "We will try to infer the conditional distribution $p(x|\\mu)$ using a conditional normalizing flow. For more examples of architectures, see unconditional_examples.ipynb. Here, we will use a `RationalQuadraticSplineTransformer` bijection with a `CouplingFlow` architecture.\n"
+                "We will try to infer the conditional distribution $p(x|\\mu)$ using a conditional normalizing flow. For more examples of architectures, see unconditional_examples.ipynb. Here, we will use a `RationalQuadraticSplineTransformer` bijection with a `coupling_flow` architecture.\n"
             ]
         },
         {
@@ -21,7 +21,7 @@
             "source": [
                 "from jax import random\n",
                 "import jax.numpy as jnp\n",
-                "from flowjax.flows import CouplingFlow\n",
+                "from flowjax.flows import coupling_flow\n",
                 "from flowjax.bijections.transformers import RationalQuadraticSplineTransformer\n",
                 "from flowjax.distributions import Normal\n",
                 "from flowjax.train_utils import train_flow\n",
@@ -77,7 +77,7 @@
             "source": [
                 "key, subkey = random.split(key)\n",
                 "\n",
-                "flow = CouplingFlow(\n",
+                "flow = coupling_flow(\n",
                 "    key=subkey,\n",
                 "    base_dist=Normal(x.shape[1]),\n",
                 "    transformer=RationalQuadraticSplineTransformer(K=8, B=3), # 8 spline segments.\n",

--- a/examples/unconditional.ipynb
+++ b/examples/unconditional.ipynb
@@ -24,7 +24,7 @@
                 "import jax\n",
                 "import jax.numpy as jnp\n",
                 "from jax import random\n",
-                "from flowjax.flows import CouplingFlow, MaskedAutoregressiveFlow\n",
+                "from flowjax.flows import coupling_flow, masked_autoregressive_flow\n",
                 "from flowjax.bijections.transformers import AffineTransformer, RationalQuadraticSplineTransformer\n",
                 "from flowjax.train_utils import train_flow\n",
                 "from flowjax.distributions import Normal\n",
@@ -100,10 +100,10 @@
                 "base_dist = Normal(x.shape[1])\n",
                 "\n",
                 "flows = {\n",
-                "    \"Affine Coupling\": CouplingFlow(flow_key, base_dist, AffineTransformer()),\n",
-                "    \"Spline Coupling\": CouplingFlow(flow_key, base_dist, RationalQuadraticSplineTransformer(K=8, B=3)),\n",
-                "    \"Affine Masked Autoregressive\": MaskedAutoregressiveFlow(flow_key, base_dist, AffineTransformer()),\n",
-                "    \"Spline Masked Autoregressive\": MaskedAutoregressiveFlow(flow_key, base_dist, RationalQuadraticSplineTransformer(K=8, B=3)),\n",
+                "    \"Affine Coupling\": coupling_flow(flow_key, base_dist, AffineTransformer()),\n",
+                "    \"Spline Coupling\": coupling_flow(flow_key, base_dist, RationalQuadraticSplineTransformer(K=8, B=3)),\n",
+                "    \"Affine Masked Autoregressive\": masked_autoregressive_flow(flow_key, base_dist, AffineTransformer()),\n",
+                "    \"Spline Masked Autoregressive\": masked_autoregressive_flow(flow_key, base_dist, RationalQuadraticSplineTransformer(K=8, B=3)),\n",
                 "}"
             ]
         },

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(filename):
 
 setup(
     name="flowjax",
-    version="4.0.2",
+    version="5.0.0",
     url="https://github.com/danielward27/flowjax.git",
     license="MIT",
     author="Daniel Ward",

--- a/tests/test_bijections/test_bijection_utils.py
+++ b/tests/test_bijections/test_bijection_utils.py
@@ -1,4 +1,4 @@
-from flowjax.bijections.utils import Flip, Permute, intertwine_flip, intertwine_random_permutation
+from flowjax.bijections.utils import Chain, Flip, Permute, intertwine_flip, intertwine_random_permutation
 import pytest
 from jax import random
 import jax.numpy as jnp
@@ -28,3 +28,11 @@ def test_intertwine_random_permutation(bijections, expected):
     "Intertwine permutations (between Flip bijections)"
     bijections = intertwine_random_permutation(random.PRNGKey(0), bijections, dim=2)
     assert [type(b) == ex for b, ex in zip(bijections, expected)]
+
+
+def test_chain_dunders():
+    b = Chain([Flip(), Permute(jnp.array([0,1]))])
+    assert len(b) == 2
+    assert isinstance(b[0], Flip)
+    assert isinstance(b[1], Permute)
+    assert isinstance(b[:], Chain)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1,4 +1,4 @@
-from flowjax.flows import CouplingFlow, BlockNeuralAutoregressiveFlow, MaskedAutoregressiveFlow
+from flowjax.flows import coupling_flow, block_neural_autoregressive_flow, masked_autoregressive_flow
 from flowjax.bijections.transformers import AffineTransformer, RationalQuadraticSplineTransformer
 from flowjax.distributions import Normal
 import jax.numpy as jnp
@@ -17,10 +17,10 @@ common_kwargs = {
 
 testcases = [
     # (name, type, kwargs)}
-    ("Affine_Coupling", CouplingFlow, {"transformer": AffineTransformer()} | common_kwargs),
-    ("RationalQuadraticSpline_Coupling", CouplingFlow, {"transformer": RationalQuadraticSplineTransformer(5,3)} | common_kwargs),
-    ("BNAF", BlockNeuralAutoregressiveFlow, {"key": random.PRNGKey(0), "base_dist": Normal(dim), "flow_layers": 2}),
-    ("Affine_MaskedAutoregessive", MaskedAutoregressiveFlow, {"transformer": AffineTransformer()} | common_kwargs)
+    ("Affine_Coupling", coupling_flow, {"transformer": AffineTransformer()} | common_kwargs),
+    ("RationalQuadraticSpline_Coupling", coupling_flow, {"transformer": RationalQuadraticSplineTransformer(5,3)} | common_kwargs),
+    ("BNAF", block_neural_autoregressive_flow, {"key": random.PRNGKey(0), "base_dist": Normal(dim), "flow_layers": 2}),
+    ("Affine_MaskedAutoregessive", masked_autoregressive_flow, {"transformer": AffineTransformer()} | common_kwargs)
 ]
 
 uncond_testcases = {n: t(**kwargs) for n, t, kwargs in testcases}


### PR DESCRIPTION
The "premade" flows are now defined as functions, returning a `Transformed` distribution object, and the names have been updated appropriately. Specifically,

- `CouplingFlow(*args)` should be changed to `coupling_flow(*args)`
- `MaskedAutoregressiveFlow(*args)` should be changed to `masked_autoregressive_flow(*args)`
- `BlockNeuralAutoregressiveFlow(*args)` should be changed to `block_neural_autoregressive_flow(*args)`

Additionally, dunder methods `Chain` bijections have been added.