### PR TITLE
Remove intertwine flip/permute

### DIFF
--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -139,47 +139,6 @@ class Flip(Bijection):
         return jnp.flip(y), jnp.array(0)
 
 
-def intertwine_flip(bijections: Sequence[Bijection]) -> List[Bijection]:
-    """Given a sequence of bijections, add 'flips' between layers, i.e.
-    with bijections [a,b,c], returns [a, flip, b, flip, c].
-
-    Args:
-        bijections (Sequence[Bijection]): Sequence of bijections.
-
-    Returns:
-        List[Bijection]: List of bijections with flips inbetween.
-    """
-    new_bijections = []
-    for b in bijections[:-1]:
-        new_bijections.extend([b, Flip()])
-    new_bijections.append(bijections[-1])
-    return new_bijections
-
-
-def intertwine_random_permutation(
-    key: KeyArray, bijections: Sequence[Bijection], dim: int
-) -> List[Bijection]:
-    """Given a list of bijections, add random permutations between layers. i.e.
-    with bijections [a,b,c], returns [a, perm1, b, perm2, c].
-
-    Args:
-        key (KeyArray): Jax PRNGKey
-        bijections (Sequence[Bijection]): Sequence of bijections.
-        dim (int): Dimension.
-
-    Returns:
-        List[Bijection]: List of bijections with random permutations inbetween.
-    """
-    new_bijections = []
-    for bijection in bijections[:-1]:
-        key, subkey = random.split(key)
-        perm = random.permutation(subkey, jnp.arange(dim))
-        new_bijections.extend([bijection, Permute(perm)])
-        
-    new_bijections.append(bijections[-1])
-    return new_bijections
-
-
 class TransformerToBijection(Bijection):
     cond_dim: int = 0
     params: Array
@@ -224,7 +183,7 @@ class Partial(Bijection):
         """
         Args:
             bijection (Bijection): Bijection that is compatible with the subset of x indexed by idxs.
-            idxs (Array): Indices (Integer, a slice, or an ndarray with integer/bool dtype) of the transformed portion. If A multidimensional array is provided, the array is flattened.
+            idxs: Indices (Integer, a slice, or an ndarray with integer/bool dtype) of the transformed portion. If a multidimensional array is provided, the array is flattened.
         """
         self.bijection = bijection
         self.cond_dim = self.bijection.cond_dim

--- a/flowjax/flows.py
+++ b/flowjax/flows.py
@@ -4,8 +4,9 @@ and examples of how flows can be constructed."""
 from typing import Optional
 from jax import random
 import jax.nn as jnn
+import jax.numpy as jnp
 from jax.random import KeyArray
-from flowjax.bijections.utils import intertwine_random_permutation, intertwine_flip
+from flowjax.bijections.utils import Permute, Flip
 from flowjax.distributions import Distribution, Transformed
 from typing import List
 from flowjax.bijections import (
@@ -39,30 +40,33 @@ def coupling_flow(
             nn_activation (int, optional): Conditioner activation function. Defaults to jnn.relu.
             invert: (bool, optional): Whether to invert the bijection. Broadly, True will prioritise a faster `inverse` methods, leading to faster `log_prob`, False will prioritise faster `transform` methods, leading to faster `sample`. Defaults to True
     """
-    permute_key, *layer_keys = random.split(key, flow_layers + 1)
+
     if permute_strategy is None:
         permute_strategy = default_permute_strategy(base_dist.dim)
-    bijections = [
-        Coupling(
-            key=key,
-            transformer=transformer,
-            d=base_dist.dim // 2,
-            D=base_dist.dim,
-            cond_dim=cond_dim,
-            nn_width=nn_width,
-            nn_depth=nn_depth,
-            nn_activation=nn_activation
-        )
-        for key in layer_keys
-    ]  # type: List[Bijection]
-    
-    if permute_strategy == "flip":
-        bijections = intertwine_flip(bijections)
-    elif permute_strategy == "random":
-        bijections = intertwine_random_permutation(permute_key, bijections, base_dist.dim)
-    elif permute_strategy != "none":
+    if permute_strategy not in ["flip", "random", "none"]:
         raise ValueError("Permute strategy should be 'flip', 'random' or 'none', if specified.")
 
+    bijections = [] # type: List[Bijection]
+    for i in range(flow_layers):
+        key, *subkeys = random.split(key, 3)
+        bijections.append(
+            Coupling(
+                key=subkeys[0],
+                transformer=transformer,
+                d=base_dist.dim // 2,
+                D=base_dist.dim,
+                cond_dim=cond_dim,
+                nn_width=nn_width,
+                nn_depth=nn_depth,
+                nn_activation=nn_activation
+            )
+        )
+        if permute_strategy == "random" and i != flow_layers:
+            perm = random.permutation(subkeys[1], jnp.arange(base_dist.dim))
+            bijections.append(Permute(perm))
+        elif permute_strategy == "flip" and i != flow_layers:
+            bijections.append(Flip())
+            
     bijection = Chain(bijections)
     if invert is True:
         bijection = Invert(bijection)
@@ -70,103 +74,112 @@ def coupling_flow(
 
 
 def masked_autoregressive_flow(
-        key: KeyArray,
-        base_dist: Distribution,
-        transformer: Transformer,
-        cond_dim: int = 0,
-        flow_layers: int = 5,
-        nn_width: int = 40,
-        nn_depth: int = 2,
-        permute_strategy: Optional[str] = None,
-        nn_activation: int = jnn.relu,
-        invert: bool = True
+    key: KeyArray,
+    base_dist: Distribution,
+    transformer: Transformer,
+    cond_dim: int = 0,
+    flow_layers: int = 5,
+    nn_width: int = 40,
+    nn_depth: int = 2,
+    permute_strategy: Optional[str] = None,
+    nn_activation: int = jnn.relu,
+    invert: bool = True
     ):
-        """Masked autoregressive flow (https://arxiv.org/abs/1705.07057v4). Parameterises a
-        a transformer with a neural network with masking of weights to enforces the
-        autoregressive property.
+    """Masked autoregressive flow (https://arxiv.org/abs/1705.07057v4). Parameterises a
+    a transformer with a neural network with masking of weights to enforces the
+    autoregressive property.
 
-        Args:
-            key (KeyArray): Random seed.
-            base_dist (Distribution): Base distribution
-            transformer (Transformer): Transformer parameterised by conditioner.
-            nn_depth (int, optional): Depth of neural network. Defaults to 2.
-            nn_width (int, optional): Number of hidden layers in neural network. Defaults to 60.
-            flow_layers (int, optional): Number of `MaskedAutoregressive` layers. Defaults to 5.
-            permute_strategy (Optional[str], optional): "flip", "random" or "none". Defaults to "flip" if dim==2, and "random" for dim > 2.
-            invert: (bool, optional): Whether to invert the bijection. Broadly, True will prioritise a faster inverse, leading to faster `log_prob`, False will prioritise faster forward, leading to faster `sample`. Defaults to True
-        """
-        permute_key, *layer_keys = random.split(key, flow_layers + 1)
-        if permute_strategy is None:
-            permute_strategy = default_permute_strategy(base_dist.dim)
+    Args:
+        key (KeyArray): Random seed.
+        base_dist (Distribution): Base distribution
+        transformer (Transformer): Transformer parameterised by conditioner.
+        nn_depth (int, optional): Depth of neural network. Defaults to 2.
+        nn_width (int, optional): Number of hidden layers in neural network. Defaults to 60.
+        flow_layers (int, optional): Number of `MaskedAutoregressive` layers. Defaults to 5.
+        permute_strategy (Optional[str], optional): "flip", "random" or "none". Defaults to "flip" if dim==2, and "random" for dim > 2.
+        invert: (bool, optional): Whether to invert the bijection. Broadly, True will prioritise a faster inverse, leading to faster `log_prob`, False will prioritise faster forward, leading to faster `sample`. Defaults to True
+    """
+    if permute_strategy is None:
+        permute_strategy = default_permute_strategy(base_dist.dim)
+    if permute_strategy not in ["flip", "random", "none"]:
+        raise ValueError("Permute strategy should be 'flip', 'random' or 'none', if specified.")
 
-        bijections = [
+    bijections = [] # type: List[Bijection]
+    for i in range(flow_layers):
+        key, *subkeys = random.split(key, 3)
+        bijections.append(
             MaskedAutoregressive(
-                key, transformer, base_dist.dim, cond_dim, nn_width, nn_depth, nn_activation
+                key=subkeys[0],
+                transformer=transformer,
+                dim=base_dist.dim,
+                cond_dim=cond_dim,
+                nn_width=nn_width,
+                nn_depth=nn_depth,
+                nn_activation=nn_activation
             )
-            for key in layer_keys
-        ]
+        )
         
-        if permute_strategy == "flip":
-            bijections = intertwine_flip(bijections)
-        elif permute_strategy == "random":
-            bijections = intertwine_random_permutation(permute_key, bijections, base_dist.dim)
-        elif permute_strategy != "none":
-            raise ValueError("Permute strategy should be 'flip', 'random' or 'none', if specified.")
-
-        bijection = Chain(bijections)
-        if invert is True:
-            bijection = Invert(bijection)
-        return Transformed(base_dist, bijection)
+        if permute_strategy == "random" and i != flow_layers:
+            perm = random.permutation(subkeys[1], jnp.arange(base_dist.dim))
+            bijections.append(Permute(perm))
+        elif permute_strategy == "flip" and i != flow_layers:
+            bijections.append(Flip())
+    
+    bijection = Chain(bijections)
+    if invert is True:
+        bijection = Invert(bijection)
+    return Transformed(base_dist, bijection)
 
 def block_neural_autoregressive_flow(
-        key: KeyArray,
-        base_dist: Distribution,
-        cond_dim: int = 0,
-        nn_depth: int = 1,
-        nn_block_dim: int = 8,
-        flow_layers: int = 1,
-        permute_strategy: Optional[str] = None,
-        invert: bool = True
-    ):
-        """Block neural autoregressive flow (BNAF) (https://arxiv.org/abs/1904.04676).
+    key: KeyArray,
+    base_dist: Distribution,
+    cond_dim: int = 0,
+    nn_depth: int = 1,
+    nn_block_dim: int = 8,
+    flow_layers: int = 1,
+    permute_strategy: Optional[str] = None,
+    invert: bool = True
+):
+    """Block neural autoregressive flow (BNAF) (https://arxiv.org/abs/1904.04676).
 
-        Args:
-            key (KeyArray): Jax PRNGKey.
-            base_dist (Distribution): Base distribution.
-            cond_dim (int): Dimension of conditional variables.
-            nn_depth (int, optional): Number of hidden layers within the networks. Defaults to 1.
-            nn_block_dim (int, optional): Block size. Hidden layer width is dim*nn_block_dim. Defaults to 8.
-            flow_layers (int, optional): Number of BNAF layers. Defaults to 1.
-            permute_strategy (Optional[str], optional): How to permute between layers. "flip", "random" or "none". Defaults to "flip" if dim==2, and "random" for dim > 2.
-            invert: (bool, optional): Use `True` for access of `log_prob` only (e.g. fitting by maximum likelihood), `False` for the forward direction (sampling) only (e.g. for fitting variationally).
-        """
-        permute_key, *layer_keys = random.split(key, flow_layers + 1)
+    Args:
+        key (KeyArray): Jax PRNGKey.
+        base_dist (Distribution): Base distribution.
+        cond_dim (int): Dimension of conditional variables.
+        nn_depth (int, optional): Number of hidden layers within the networks. Defaults to 1.
+        nn_block_dim (int, optional): Block size. Hidden layer width is dim*nn_block_dim. Defaults to 8.
+        flow_layers (int, optional): Number of BNAF layers. Defaults to 1.
+        permute_strategy (Optional[str], optional): How to permute between layers. "flip", "random" or "none". Defaults to "flip" if dim==2, and "random" for dim > 2.
+        invert: (bool, optional): Use `True` for access of `log_prob` only (e.g. fitting by maximum likelihood), `False` for the forward direction (sampling) only (e.g. for fitting variationally).
+    """
+    if permute_strategy is None:
+        permute_strategy = default_permute_strategy(base_dist.dim)
+    if permute_strategy not in ["flip", "random", "none"]:
+        raise ValueError("Permute strategy should be 'flip', 'random' or 'none', if specified.")
 
-        if permute_strategy is None:
-            permute_strategy = default_permute_strategy(base_dist.dim)
-
-        bijections = [
+    bijections = [] # type: List[Bijection]
+    for i in range(flow_layers):
+        key, *subkeys = random.split(key, 3)
+        bijections.append(
             BlockAutoregressiveNetwork(
-                key,
+                key=subkeys[0],
                 dim=base_dist.dim,
                 cond_dim=cond_dim,
                 depth=nn_depth,
                 block_dim=nn_block_dim,
             )
-            for key in layer_keys
-        ]  # type: List[Bijection]
+        )
 
-        if permute_strategy == "flip":
-            bijections = intertwine_flip(bijections)
-        elif permute_strategy == "random":
-            bijections = intertwine_random_permutation(permute_key, bijections, base_dist.dim)
-        elif permute_strategy != "none":
-            raise ValueError("Permute strategy should be 'flip', 'random' or 'none', if specified.")
+        if permute_strategy == "random" and i != flow_layers:
+            perm = random.permutation(subkeys[1], jnp.arange(base_dist.dim))
+            bijections.append(Permute(perm))
+        elif permute_strategy == "flip" and i != flow_layers:
+            bijections.append(Flip())
 
-        bijection = Chain(bijections)
-        if invert is True:
-            bijection = Invert(bijection)
-        return Transformed(base_dist, bijection)
+    bijection = Chain(bijections)
+    if invert is True:
+        bijection = Invert(bijection)
+    return Transformed(base_dist, bijection)
 
 
 def default_permute_strategy(dim):
@@ -174,6 +187,3 @@ def default_permute_strategy(dim):
         return {1: "none", 2: "flip"}[dim]
     else:
         return "random"
-
-
-

--- a/tests/test_bijections/test_bijection_utils.py
+++ b/tests/test_bijections/test_bijection_utils.py
@@ -1,35 +1,8 @@
-from flowjax.bijections.utils import Chain, Flip, Permute, intertwine_flip, intertwine_random_permutation, Partial
+from flowjax.bijections.utils import Chain, Flip, Permute, Partial
 from flowjax.bijections import Affine
 import pytest
 from jax import random
 import jax.numpy as jnp
-
-
-perm = jnp.array([0,1])
-test_cases = {
-    # {name: (inputs, expected)}
-    "Len 3": ([Permute(perm) for _ in range(3)], [Permute, Flip, Permute, Flip, Permute]),
-    "Len 1": ([Permute(perm)], [Permute])
-}
-
-@pytest.mark.parametrize("bijections,expected", test_cases.values(), ids=test_cases.keys())
-def test_intertwine_flip(bijections, expected):
-    "Intertwine flips (between permutation bijections)"
-    bijections = intertwine_flip(bijections)
-    assert [type(b) == ex for b, ex in zip(bijections, expected)]
-
-
-test_cases = {
-    "Len 3": ([Flip() for _ in range(3)], [Flip, Permute, Flip, Permute, Flip]),
-    "Len 1": ([Flip()], [Flip])
-}
-
-@pytest.mark.parametrize("bijections,expected", test_cases.values(), ids=test_cases.keys())
-def test_intertwine_random_permutation(bijections, expected):
-    "Intertwine permutations (between Flip bijections)"
-    bijections = intertwine_random_permutation(random.PRNGKey(0), bijections, dim=2)
-    assert [type(b) == ex for b, ex in zip(bijections, expected)]
-
 
 def test_chain_dunders():
     b = Chain([Flip(), Permute(jnp.array([0,1]))])
@@ -53,5 +26,3 @@ def test_partial(idx, num_transformed, expected):
     bijection = Partial(Affine(jnp.ones(num_transformed)), idx)
     y = bijection.transform(x)
     assert jnp.all((x!=y)==expected)
-
-    


### PR DESCRIPTION
Removed the functions `intertwine_flip` and `intertwine_permute`. Appending bijections (including permutations) within a for loop instead has similar convenience and is arguably clearer.