### PR TITLE
Sample and log prob

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+
+### Documentation
+
+The documentation is supported by [Sphinx](https://www.sphinx-doc.org/en/master/). To build the docs, run from the top level directory:
+```
+sphinx-build docs docs/_build
+```
+
+To test the doctest code blocks in the documentation, run from the top level directory:
+```
+make -C docs doctest
+```
+
+Github Actions is used for continuous integration, and the tests will fail if either the documentation does not build, or any doctest examples fail.


### PR DESCRIPTION
Adds a `sample_and_log_prob` method for `Distribution`. In `Distribution` this relies on `_sample` and `_log_prob` methods separately. However, for `Transformed` distributions, we reimplement it to avoid computing  the inverse transformation.