### PR TITLE
Simplify types in docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/setup-python@v2
       - name: Install pandoc
         run: |
-          sudo apt update
-          sudo apt install -y pandoc
+          sudo apt-get update
+          sudo apt-get install -y pandoc
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,8 +8,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
       - name: Install pandoc
         run: |
           sudo apt-get update

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,3 +49,6 @@ html_theme_options = {
 }
 
 pygments_style = "xcode"
+
+autodoc_typehints = "none"
+autodoc_preserve_defaults = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,4 @@ html_theme_options = {
 }
 
 pygments_style = "xcode"
-
 autodoc_typehints = "none"
-autodoc_preserve_defaults = True

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -33,7 +33,7 @@ In general you should consider the form and scales of the target samples. For ex
     import jax.random as jr
     
     key = jr.PRNGKey(0)
-    x = jr.normal(key, (256,3))
+    x = jr.normal(key, (1000,3))
     flow = Normal(jnp.ones(3))
 
 .. doctest::
@@ -54,7 +54,6 @@ The methods of distributions and bijections are not jitted by default. For examp
 .. testsetup::
 
     from flowjax.distributions import Normal
-    from flowjax.train import fit_to_data
     import jax.numpy as jnp
     import jax.random as jr
     

--- a/flowjax/train/data_fit.py
+++ b/flowjax/train/data_fit.py
@@ -29,13 +29,13 @@ def fit_to_data(
     show_progress: bool = True,
 ):
     """Train a distribution (e.g. a flow) to samples by maximum likelihood. Note that
-        the last batch in each epoch is dropped if truncated.
+    the last batch in each epoch is dropped if truncated.
 
     Args:
         key (KeyArray): Jax PRNGKey.
         dist (Distribution): Distribution object.
-        x (Array): Samples from target distribution.
-        condition (Array | None): Conditioning variables. Defaults to None.
+        x (ArrayLike): Samples from target distribution.
+        condition (ArrayLike | None): Conditioning variables. Defaults to None.
         max_epochs (int): Maximum number of epochs. Defaults to 50.
         max_patience (int): Number of consecutive epochs with no validation
             loss improvement after which training is terminated. Defaults to 5.

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -44,15 +44,15 @@ def fit_to_variational_target(
     (e.g. an unnormalized density).
 
     Args:
-        key (KeyArray): Jax PRNGKey.
+        key (jr.KeyArray): Jax PRNGKey.
         dist (Distribution): Distribution object, trainable parameters are found
             using equinox.is_inexact_array.
-        target (Callable): The variational target (this is usually the unormalized log
+        target (Callable[[Array], Array]): The variational target (this is usually the unormalized log
             posterior)
-        loss_fn (Callable): The loss function to optimize. The loss function
-            should take a random key, the distribution, a callable that maps samples
-            from the distribution to a scalar loss, and a number of samples to use.
-            Defaults to elbo_loss.
+        loss_fn (Callable[[Distribution, Callable, jr.KeyArray, int], Array]): The loss
+            function to optimize. The loss function should take the distribution to train,
+            the target function, key and an int (number of samples) and map to a scalar
+            loss. Defaults to elbo_loss.
         steps (int): The number of training steps to run. Defaults to 100.
         samples_per_step (int): number of samples to use at each step.
             Defaults to 500.

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -12,7 +12,6 @@ from flowjax.distributions import Distribution
 PyTree = Any
 
 
-@eqx.filter_jit
 def elbo_loss(
     dist: Distribution,
     target: Callable[[Array], Array],


### PR DESCRIPTION
Only show types under parameters (not in the signature).