### PR TITLE
Arraylike

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "FlowJax"
 copyright = "2022, Daniel Ward"
 author = "Daniel Ward"
-release = "v9.0.0"
+release = "v9.1.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/flowjax/__init__.py
+++ b/flowjax/__init__.py
@@ -1,5 +1,5 @@
 """flowjax - Basic flowjax implementation in jax."""
 
-__version__ = "9.0.0"
+__version__ = "9.1.0"
 __author__ = "Daniel Ward <danielward27@outlook.com>"
 __all__ = []

--- a/flowjax/bijections/__init__.py
+++ b/flowjax/bijections/__init__.py
@@ -1,6 +1,6 @@
 """Bijections from ``flowjax.bijections``"""
 
-from .affine import AdditiveLinearCondition, Affine, TriangularAffine
+from .affine import AdditiveLinearCondition, Affine, TriangularAffine, AdditiveCondition
 from .bijection import Bijection
 from .block_autoregressive_network import BlockAutoregressiveNetwork
 from .chain import Chain
@@ -31,6 +31,7 @@ __all__ = [
     "Flip",
     "Permute",
     "AdditiveLinearCondition",
+    "AdditiveCondition",
     "Partial",
     "EmbedCondition",
     "RationalQuadraticSpline",

--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -7,6 +7,7 @@ from jax.experimental import checkify
 from jax.scipy.linalg import solve_triangular
 from jax.typing import ArrayLike
 import warnings
+from flowjax.utils import arraylike_to_array
 
 from flowjax.bijections.bijection import Bijection
 
@@ -25,7 +26,7 @@ class Affine(Bijection):
             loc (ArrayLike): Location parameter. Defaults to 0.
             scale (ArrayLike): Scale parameter. Defaults to 1.
         """
-        loc, scale = [jnp.asarray(a, dtype=float) for a in (loc, scale)]
+        loc, scale = [arraylike_to_array(a, dtype=float) for a in (loc, scale)]
         self.shape = jnp.broadcast_shapes(jnp.shape(loc), jnp.shape(scale))
         self.cond_shape = None
 
@@ -81,7 +82,7 @@ class TriangularAffine(Bijection):
             weight_log_scale (Array | None): If provided, carry out weight
                 normalisation.
         """
-        loc, arr = jnp.asarray(loc), jnp.asarray(arr)
+        loc, arr = [arraylike_to_array(a, dtype=float) for a in (loc, arr)]
         if (arr.ndim != 2) or (arr.shape[0] != arr.shape[1]):
             raise ValueError("arr must be a square, 2-dimensional matrix.")
         checkify.check(

--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -25,7 +25,7 @@ class Affine(Bijection):
             loc (ArrayLike): Location parameter. Defaults to 0.
             scale (ArrayLike): Scale parameter. Defaults to 1.
         """
-        loc, scale = [jnp.asarray(a, dtype=jnp.float32) for a in (loc, scale)]
+        loc, scale = [jnp.asarray(a, dtype=float) for a in (loc, scale)]
         self.shape = jnp.broadcast_shapes(jnp.shape(loc), jnp.shape(scale))
         self.cond_shape = None
 

--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -161,6 +161,21 @@ class AdditiveCondition(Bijection):
                 that is broadcastable with the shape of the bijection.
             shape (tuple[int, ...]): The shape of the bijection.
             cond_shape (tuple[int, ...]): The condition shape of the bijection.
+
+        Example:
+            Conditioning using a linear transformation
+
+            .. doctest::
+
+                >>> from flowjax.bijections import AdditiveCondition
+                >>> from equinox.nn import Linear
+                >>> import jax.numpy as jnp
+                >>> import jax.random as jr
+                >>> bijection = AdditiveCondition(
+                >>>     Linear(2, 3, key=jr.PRNGKey(0)), shape=(3,), cond_shape=(2,)
+                >>>     )
+                >>> bijection.transform(jnp.ones(3), condition=jnp.ones(2))
+                Array([1.9670618, 0.8156546, 1.7763454], dtype=float32)
         """
         self.module = module
         self.shape = shape

--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -67,20 +67,21 @@ class TriangularAffine(Bijection):
 
     def __init__(
         self,
-        loc: Array,
-        arr: Array,
+        loc: ArrayLike,
+        arr: ArrayLike,
         lower: bool = True,
         weight_normalisation: bool = False,
     ):
         """
         Args:
-            loc (Array): Location parameter.
-            arr (Array): Triangular matrix.
+            loc (ArrayLike): Location parameter.
+            arr (ArrayLike): Triangular matrix.
             lower (bool): Whether the mask should select the lower or upper
                 triangular matrix (other elements ignored). Defaults to True.
             weight_log_scale (Array | None): If provided, carry out weight
                 normalisation.
         """
+        loc, arr = jnp.asarray(loc), jnp.asarray(arr)
         if (arr.ndim != 2) or (arr.shape[0] != arr.shape[1]):
             raise ValueError("arr must be a square, 2-dimensional matrix.")
         checkify.check(

--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -172,8 +172,8 @@ class AdditiveCondition(Bijection):
                 >>> import jax.numpy as jnp
                 >>> import jax.random as jr
                 >>> bijection = AdditiveCondition(
-                >>>     Linear(2, 3, key=jr.PRNGKey(0)), shape=(3,), cond_shape=(2,)
-                >>>     )
+                ...     Linear(2, 3, key=jr.PRNGKey(0)), shape=(3,), cond_shape=(2,)
+                ...     )
                 >>> bijection.transform(jnp.ones(3), condition=jnp.ones(2))
                 Array([1.9670618, 0.8156546, 1.7763454], dtype=float32)
         """

--- a/flowjax/bijections/bijection.py
+++ b/flowjax/bijections/bijection.py
@@ -10,6 +10,8 @@ from abc import abstractmethod
 
 from equinox import Module
 from jax import Array
+from jax.typing import ArrayLike
+import jax.numpy as jnp
 
 
 class Bijection(Module):
@@ -42,35 +44,45 @@ class Bijection(Module):
     cond_shape: tuple[int, ...] | None
 
     @abstractmethod
-    def transform(self, x: Array, condition: Array | None = None) -> Array:
+    def transform(self, x: ArrayLike, condition: ArrayLike | None = None) -> Array:
         """Apply transformation."""
 
     @abstractmethod
     def transform_and_log_det(
-        self, x: Array, condition: Array | None = None
+        self, x: ArrayLike, condition: ArrayLike | None = None
     ) -> tuple[Array, Array]:
         """Apply transformation and compute log absolute value of the Jacobian determinant."""
 
     @abstractmethod
-    def inverse(self, y: Array, condition: Array | None = None) -> Array:
+    def inverse(self, y: ArrayLike, condition: ArrayLike | None = None) -> Array:
         """Invert the transformation."""
 
     @abstractmethod
     def inverse_and_log_det(
-        self, y: Array, condition: Array | None = None
+        self, y: ArrayLike, condition: ArrayLike | None = None
     ) -> tuple[Array, Array]:
         """Invert the transformation and compute log absolute value of the Jacobian determinant."""
 
-    def _argcheck(self, x: Array, condition: Array | None = None):
-        """Utility argcheck that can be added to bijection methods as required."""
-        if self.shape is not None:
-            if x.shape != self.shape:
-                raise ValueError(f"Expected x.shape {self.shape}, got {x.shape}")
+    def _argcheck_and_cast(
+        self, x: ArrayLike, condition: ArrayLike | None = None
+    ) -> tuple[Array, Array | None]:
+        """Utility function that checks input shapes against the bijection shapes,
+        and casts inputs to arrays if required. Note this permits passing a condition
+        in the case when bijection.cond_shape is None."""
+        if not isinstance(x, ArrayLike):
+            raise ValueError(f"Expected arraylike input; got {x}")
+        x = jnp.asarray(x)
 
-        if self.cond_shape is not None:
-            if condition is None:
-                raise ValueError("Condition should be provided")
-            if condition.shape != self.cond_shape:
+        if x.shape != self.shape:
+            raise ValueError(f"Expected x.shape {self.shape}; got {x.shape}")
+
+        if isinstance(condition, ArrayLike):
+            condition = jnp.asarray(condition)
+            if self.cond_shape is not None and condition.shape != self.cond_shape:
                 raise ValueError(
-                    f"Expected condition.shape {self.cond_shape}, got {condition.shape}"
+                    f"Expected condition.shape {self.cond_shape}; got {condition.shape}"
                 )
+        elif self.cond_shape is not None:
+            raise ValueError(f"Expected condition to be arraylike; got {condition}")
+
+        return x, condition

--- a/flowjax/bijections/bijection.py
+++ b/flowjax/bijections/bijection.py
@@ -11,7 +11,8 @@ from abc import abstractmethod
 from equinox import Module
 from jax import Array
 from jax.typing import ArrayLike
-import jax.numpy as jnp
+
+from flowjax.utils import arraylike_to_array
 
 
 class Bijection(Module):
@@ -69,20 +70,17 @@ class Bijection(Module):
         """Utility function that checks input shapes against the bijection shapes,
         and casts inputs to arrays if required. Note this permits passing a condition
         in the case when bijection.cond_shape is None."""
-        if not isinstance(x, ArrayLike):
-            raise ValueError(f"Expected arraylike input; got {x}")
-        x = jnp.asarray(x)
+        x = arraylike_to_array(x, err_name="x")
 
         if x.shape != self.shape:
             raise ValueError(f"Expected x.shape {self.shape}; got {x.shape}")
 
-        if isinstance(condition, ArrayLike):
-            condition = jnp.asarray(condition)
+        if condition is not None:
+            condition = arraylike_to_array(condition, err_name="condition")
+
             if self.cond_shape is not None and condition.shape != self.cond_shape:
                 raise ValueError(
                     f"Expected condition.shape {self.cond_shape}; got {condition.shape}"
                 )
-        elif self.cond_shape is not None:
-            raise ValueError(f"Expected condition to be arraylike; got {condition}")
 
         return x, condition

--- a/flowjax/bijections/block_autoregressive_network.py
+++ b/flowjax/bijections/block_autoregressive_network.py
@@ -70,14 +70,14 @@ class BlockAutoregressiveNetwork(Bijection):
         self.cond_shape = (cond_dim,) if cond_dim is not None else None
 
     def transform(self, x, condition=None):
-        self._argcheck(x, condition)
+        x, condition = self._argcheck_and_cast(x, condition)
         x = self.layers[0](x, condition)[0]
         for layer in self.layers[1:]:
             x = layer(x)[0]
         return x
 
     def transform_and_log_det(self, x, condition=None):
-        self._argcheck(x, condition)
+        x, condition = self._argcheck_and_cast(x, condition)
         x, log_jacobian_3d_0 = self.layers[0](x, condition)
         log_jacobian_3ds = [log_jacobian_3d_0]
         for layer in self.layers[1:]:

--- a/flowjax/bijections/chain.py
+++ b/flowjax/bijections/chain.py
@@ -36,7 +36,7 @@ class Chain(Bijection):
             log_abs_det_jac += log_abs_det_jac_i.sum()
         return x, log_abs_det_jac
 
-    def inverse(self, y: Array, condition=None):
+    def inverse(self, y, condition=None):
         for bijection in reversed(self.bijections):
             y = bijection.inverse(y, condition)
         return y

--- a/flowjax/bijections/concatenate.py
+++ b/flowjax/bijections/concatenate.py
@@ -38,7 +38,7 @@ class Concatenate(Bijection):
         self.cond_shape = merge_cond_shapes([b.cond_shape for b in bijections])
 
     def transform(self, x, condition=None):
-        self._argcheck(x, condition)
+        x, condition = self._argcheck_and_cast(x, condition)
         x_parts = jnp.array_split(x, self.split_idxs, axis=self.axis)
         y_parts = [
             b.transform(x_part, condition)
@@ -47,7 +47,7 @@ class Concatenate(Bijection):
         return jnp.concatenate(y_parts, axis=self.axis)
 
     def transform_and_log_det(self, x, condition=None):
-        self._argcheck(x, condition)
+        x, condition = self._argcheck_and_cast(x, condition)
         x_parts = jnp.array_split(x, self.split_idxs, axis=self.axis)
 
         ys_log_dets = [
@@ -59,7 +59,7 @@ class Concatenate(Bijection):
         return jnp.concatenate(y_parts, self.axis), sum(log_dets)
 
     def inverse(self, y, condition=None):
-        self._argcheck(y, condition)
+        y, condition = self._argcheck_and_cast(y, condition)
         y_parts = jnp.array_split(y, self.split_idxs, axis=self.axis)
         x_parts = [
             b.inverse(y_part, condition) for b, y_part in zip(self.bijections, y_parts)
@@ -67,7 +67,7 @@ class Concatenate(Bijection):
         return jnp.concatenate(x_parts, axis=self.axis)
 
     def inverse_and_log_det(self, y, condition=None):
-        self._argcheck(y, condition)
+        y, condition = self._argcheck_and_cast(y, condition)
         y_parts = jnp.array_split(y, self.split_idxs, axis=self.axis)
 
         xs_log_dets = [
@@ -114,7 +114,7 @@ class Stack(Bijection):
         self.cond_shape = merge_cond_shapes([b.cond_shape for b in bijections])
 
     def transform(self, x, condition=None):
-        self._argcheck(x, condition)
+        x, condition = self._argcheck_and_cast(x, condition)
         x_parts = self._split_and_squeeze(x)
         y_parts = [
             b.transform(x, condition) for (b, x) in zip(self.bijections, x_parts)
@@ -122,7 +122,7 @@ class Stack(Bijection):
         return jnp.stack(y_parts, self.axis)
 
     def transform_and_log_det(self, x, condition=None):
-        self._argcheck(x, condition)
+        x, condition = self._argcheck_and_cast(x, condition)
         x_parts = self._split_and_squeeze(x)
         ys_log_det = [
             b.transform_and_log_det(x, condition)
@@ -133,13 +133,13 @@ class Stack(Bijection):
         return jnp.stack(y_parts, self.axis), sum(log_dets)
 
     def inverse(self, y, condition=None):
-        self._argcheck(y, condition)
+        y, condition = self._argcheck_and_cast(y, condition)
         y_parts = self._split_and_squeeze(y)
         x_parts = [b.inverse(y, condition) for (b, y) in zip(self.bijections, y_parts)]
         return jnp.stack(x_parts, self.axis)
 
     def inverse_and_log_det(self, y, condition=None):
-        self._argcheck(y, condition)
+        y, condition = self._argcheck_and_cast(y, condition)
         y_parts = self._split_and_squeeze(y)
         xs_log_det = [
             b.inverse_and_log_det(y, condition)

--- a/flowjax/bijections/exp.py
+++ b/flowjax/bijections/exp.py
@@ -17,18 +17,18 @@ class Exp(Bijection):
         self.cond_shape = None
 
     def transform(self, x, condition=None):
-        self._argcheck(x)
+        x, _ = self._argcheck_and_cast(x)
         return jnp.exp(x)
 
     def transform_and_log_det(self, x, condition=None):
-        self._argcheck(x)
+        x, _ = self._argcheck_and_cast(x)
         return jnp.exp(x), x.sum()
 
     def inverse(self, y, condition=None):
-        self._argcheck(y)
+        y, _ = self._argcheck_and_cast(y)
         return jnp.log(y)
 
     def inverse_and_log_det(self, y, condition=None):
-        self._argcheck(y)
+        y, _ = self._argcheck_and_cast(y)
         x = jnp.log(y)
         return x, -x.sum()

--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -12,17 +12,6 @@ class Batch(Bijection):
     """Add batch dimensions to a bijection, such that the new shape is
     batch_shape + bijection.shape. The batch dimensions are added using multiple
     applications of eqx.filter_vmap.
-
-    Example:
-
-    .. doctest::
-
-        >>> import jax.numpy as jnp
-        >>> from flowjax.bijections import Batch, Affine
-        >>> x = jnp.ones(2)
-        >>> batched = Batch(Affine(1), (2,), vectorize_bijection=False)
-        >>> batched.transform(x)
-        Array([2., 2.], dtype=float32)
     """
 
     bijection: Bijection
@@ -46,12 +35,21 @@ class Batch(Bijection):
                 have leading dimensions equal to batch_shape. For construction of
                 compatible bijections, see ``eqx.filter_vmap``. If False: we broadcast
                 the parameters, i.e. the same bijection parameters are used for each x.
-
-
             vectorize_condition (bool | None): Whether to vectorize or broadcast the
                 conditioning variables. If broadcasting, the condition shape is
                 unchanged. If vectorising, the condition shape will be
                 ``batch_shape + bijection.cond_shape``. Defaults to None.
+
+        Example:
+
+            .. doctest::
+
+                >>> import jax.numpy as jnp
+                >>> from flowjax.bijections import Batch, Affine
+                >>> x = jnp.ones(2)
+                >>> batched = Batch(Affine(1), (2,), vectorize_bijection=False)
+                >>> batched.transform(x)
+                Array([2., 2.], dtype=float32)
         """
         if vectorize_condition is None and bijection.cond_shape is not None:
             raise ValueError(

--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -75,7 +75,7 @@ class Batch(Bijection):
             self.cond_shape = self.bijection.cond_shape
 
     def transform(self, x, condition=None):
-        self._argcheck(x, condition)
+        x, condition = self._argcheck_and_cast(x, condition)
 
         def _transform(bijection, x, condition):
             return bijection.transform(x, condition)
@@ -83,7 +83,7 @@ class Batch(Bijection):
         return self.multi_vmap(_transform)(self.bijection, x, condition)
 
     def transform_and_log_det(self, x, condition=None):
-        self._argcheck(x, condition)
+        x, condition = self._argcheck_and_cast(x, condition)
 
         def _transform_and_log_det(bijection, x, condition):
             return bijection.transform_and_log_det(x, condition)
@@ -94,7 +94,7 @@ class Batch(Bijection):
         return y, jnp.sum(log_det)
 
     def inverse(self, y, condition=None):
-        self._argcheck(y, condition)
+        y, condition = self._argcheck_and_cast(y, condition)
 
         def _inverse(bijection, x, condition):
             return bijection.inverse(x, condition)
@@ -102,7 +102,7 @@ class Batch(Bijection):
         return self.multi_vmap(_inverse)(self.bijection, y, condition)
 
     def inverse_and_log_det(self, y, condition=None):
-        self._argcheck(y, condition)
+        y, condition = self._argcheck_and_cast(y, condition)
 
         def _inverse_and_log_det(bijection, x, condition):
             return bijection.inverse_and_log_det(x, condition)
@@ -152,7 +152,7 @@ class Scan(Bijection):
         self.cond_shape = bijection.cond_shape
 
     def transform(self, x, condition=None):
-        self._argcheck(x, condition)
+        x, condition = self._argcheck_and_cast(x, condition)
 
         def step(x, params, condition=None):
             bijection = eqx.combine(self.static, params)
@@ -164,7 +164,7 @@ class Scan(Bijection):
         return y
 
     def transform_and_log_det(self, x, condition=None):
-        self._argcheck(x, condition)
+        x, condition = self._argcheck_and_cast(x, condition)
 
         def step(carry, params, condition):
             x, log_det = carry
@@ -177,7 +177,7 @@ class Scan(Bijection):
         return y, log_det
 
     def inverse(self, y, condition=None):
-        self._argcheck(y, condition)
+        y, _ = self._argcheck_and_cast(y, condition)
 
         def step(y, params, condition):
             bijection = eqx.combine(self.static, params)
@@ -189,7 +189,7 @@ class Scan(Bijection):
         return x
 
     def inverse_and_log_det(self, y, condition=None):
-        self._argcheck(y, condition)
+        y, _ = self._argcheck_and_cast(y, condition)
 
         def step(carry, params, condition):
             y, log_det = carry

--- a/flowjax/bijections/tanh.py
+++ b/flowjax/bijections/tanh.py
@@ -24,19 +24,19 @@ class Tanh(Bijection):
         self.cond_shape = None
 
     def transform(self, x, condition=None):
-        self._argcheck(x)
+        x, _ = self._argcheck_and_cast(x)
         return jnp.tanh(x)
 
     def transform_and_log_det(self, x, condition=None):
-        self._argcheck(x)
+        x, _ = self._argcheck_and_cast(x)
         return jnp.tanh(x), jnp.sum(_tanh_log_grad(x))
 
     def inverse(self, y, condition=None):
-        self._argcheck(y)
+        y, _ = self._argcheck_and_cast(y)
         return jnp.arctanh(y)
 
     def inverse_and_log_det(self, y, condition=None):
-        self._argcheck(y)
+        y, _ = self._argcheck_and_cast(y)
         x = jnp.arctanh(y)
         return x, -jnp.sum(_tanh_log_grad(x))
 
@@ -69,14 +69,14 @@ class TanhLinearTails(Bijection):
         self.cond_shape = None
 
     def transform(self, x, condition=None):
-        self._argcheck(x)
+        x, _ = self._argcheck_and_cast(x)
         is_linear = jnp.abs(x) >= self.max_val
         linear_y = self.linear_grad * x + jnp.sign(x) * self.intercept
         tanh_y = jnp.tanh(x)
         return jnp.where(is_linear, linear_y, tanh_y)
 
     def transform_and_log_det(self, x, condition=None):
-        self._argcheck(x)
+        x, _ = self._argcheck_and_cast(x)
         y = self.transform(x)
         log_grads = jnp.where(
             jnp.abs(x) >= self.max_val, jnp.log(self.linear_grad), _tanh_log_grad(x)
@@ -84,14 +84,14 @@ class TanhLinearTails(Bijection):
         return y, jnp.sum(log_grads)  # type: ignore
 
     def inverse(self, y, condition=None):
-        self._argcheck(y)
+        y, _ = self._argcheck_and_cast(y)
         is_linear = jnp.abs(y) >= jnp.tanh(self.max_val)
         x_linear = (y - jnp.sign(y) * self.intercept) / self.linear_grad
         x_arctan = jnp.arctanh(y)
         return jnp.where(is_linear, x_linear, x_arctan)
 
     def inverse_and_log_det(self, y, condition=None):
-        self._argcheck(y)
+        y, _ = self._argcheck_and_cast(y)
         x = self.inverse(y)
         log_grads = jnp.where(
             jnp.abs(y) >= jnp.tanh(self.max_val),

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -142,22 +142,22 @@ class Partial(Bijection):
                 f"while the subset has a shape of {jnp.zeros(shape)[idxs].shape}."
             )
 
-    def transform(self, x: Array, condition=None):
+    def transform(self, x, condition=None):
         x, condition = self._argcheck_and_cast(x, condition)
         y = self.bijection.transform(x[self.idxs], condition)
         return x.at[self.idxs].set(y)
 
-    def transform_and_log_det(self, x: Array, condition=None):
+    def transform_and_log_det(self, x, condition=None):
         x, condition = self._argcheck_and_cast(x, condition)
         y, log_det = self.bijection.transform_and_log_det(x[self.idxs], condition)
         return x.at[self.idxs].set(y), log_det
 
-    def inverse(self, y: Array, condition=None):
+    def inverse(self, y, condition=None):
         y, condition = self._argcheck_and_cast(y, condition)
         x = self.bijection.inverse(y[self.idxs], condition)
         return y.at[self.idxs].set(x)
 
-    def inverse_and_log_det(self, y: Array, condition=None):
+    def inverse_and_log_det(self, y, condition=None):
         y, condition = self._argcheck_and_cast(y, condition)
         x, log_det = self.bijection.inverse_and_log_det(y[self.idxs], condition)
         return y.at[self.idxs].set(x), log_det

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -4,7 +4,7 @@ from typing import Callable
 import jax.numpy as jnp
 from jax import Array
 from jax.experimental import checkify
-
+from jax.typing import ArrayLike
 from flowjax.bijections.bijection import Bijection
 
 
@@ -47,13 +47,14 @@ class Permute(Bijection):
     permutation: tuple[Array, ...]
     inverse_permutation: tuple[Array, ...]
 
-    def __init__(self, permutation: Array):
+    def __init__(self, permutation: ArrayLike):
         """
         Args:
-            permutation (Array): An array with shape matching the array to transform,
+            permutation (ArrayLike): An array with shape matching the array to transform,
                 with elements 0-(array.size-1) representing the new order based on the
                 flattened array (uses, C-like ordering).
         """
+        permutation = jnp.asarray(permutation)
         checkify.check(
             (permutation.ravel().sort() == jnp.arange(permutation.size)).all(),
             "Invalid permutation array provided.",

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -72,17 +72,19 @@ class Permute(Bijection):
         )
 
     def transform(self, x, condition=None):
-        self._argcheck(x)
+        x, _ = self._argcheck_and_cast(x)
         return x[self.permutation]
 
     def transform_and_log_det(self, x, condition=None):
+        x, _ = self._argcheck_and_cast(x)
         return x[self.permutation], jnp.array(0)
 
     def inverse(self, y, condition=None):
-        self._argcheck(y)
+        y, _ = self._argcheck_and_cast(y)
         return y[self.inverse_permutation]
 
     def inverse_and_log_det(self, y, condition=None):
+        x, _ = self._argcheck_and_cast(y)
         return y[self.inverse_permutation], jnp.array(0)
 
 
@@ -98,19 +100,19 @@ class Flip(Bijection):
         self.cond_shape = None
 
     def transform(self, x, condition=None):
-        self._argcheck(x)
+        x, _ = self._argcheck_and_cast(x)
         return jnp.flip(x)
 
     def transform_and_log_det(self, x, condition=None):
-        self._argcheck(x)
+        x, _ = self._argcheck_and_cast(x)
         return jnp.flip(x), jnp.array(0)
 
     def inverse(self, y, condition=None):
-        self._argcheck(y)
+        y, _ = self._argcheck_and_cast(y)
         return jnp.flip(y)
 
     def inverse_and_log_det(self, y, condition=None):
-        self._argcheck(y)
+        y, _ = self._argcheck_and_cast(y)
         return jnp.flip(y), jnp.array(0)
 
 
@@ -141,22 +143,22 @@ class Partial(Bijection):
             )
 
     def transform(self, x: Array, condition=None):
-        self._argcheck(x)
+        x, condition = self._argcheck_and_cast(x, condition)
         y = self.bijection.transform(x[self.idxs], condition)
         return x.at[self.idxs].set(y)
 
     def transform_and_log_det(self, x: Array, condition=None):
-        self._argcheck(x)
+        x, condition = self._argcheck_and_cast(x, condition)
         y, log_det = self.bijection.transform_and_log_det(x[self.idxs], condition)
         return x.at[self.idxs].set(y), log_det
 
     def inverse(self, y: Array, condition=None):
-        self._argcheck(y)
+        y, condition = self._argcheck_and_cast(y, condition)
         x = self.bijection.inverse(y[self.idxs], condition)
         return y.at[self.idxs].set(x)
 
     def inverse_and_log_det(self, y: Array, condition=None):
-        self._argcheck(y)
+        y, condition = self._argcheck_and_cast(y, condition)
         x, log_det = self.bijection.inverse_and_log_det(y[self.idxs], condition)
         return y.at[self.idxs].set(x), log_det
 
@@ -191,21 +193,21 @@ class EmbedCondition(Bijection):
         self.cond_shape = raw_cond_shape
 
     def transform(self, x, condition=None):
-        self._argcheck(x, condition)
+        x, condition = self._argcheck_and_cast(x, condition)
         condition = self.embedding_net(condition)
         return self.bijection.transform(x, condition)
 
     def transform_and_log_det(self, x, condition=None):
-        self._argcheck(x, condition)
+        x, condition = self._argcheck_and_cast(x, condition)
         condition = self.embedding_net(condition)
         return self.bijection.transform_and_log_det(x, condition)
 
     def inverse(self, y, condition=None):
-        self._argcheck(y, condition)
+        y, condition = self._argcheck_and_cast(y, condition)
         condition = self.embedding_net(condition)
         return self.bijection.inverse(y, condition)
 
     def inverse_and_log_det(self, y, condition=None):
-        self._argcheck(y, condition)
+        y, condition = self._argcheck_and_cast(y, condition)
         condition = self.embedding_net(condition)
         return self.bijection.inverse_and_log_det(y, condition)

--- a/flowjax/distributions.py
+++ b/flowjax/distributions.py
@@ -226,8 +226,6 @@ class Distribution(eqx.Module):
         keys = jnp.reshape(jr.split(key, key_size), key_shape + (2,))  # type: ignore
         return keys
 
-    # jnp.vectorize would catch ndim mismatches, but it doesn't check axis lengths.
-
     def _argcheck_and_cast_x(self, x) -> Array:
         if not isinstance(x, ArrayLike):
             raise ValueError(f"Expected x to be arraylike; got {x}")
@@ -364,8 +362,8 @@ class Normal(Transformed):
     def __init__(self, loc: ArrayLike = 0, scale: ArrayLike = 1):
         """
         Args:
-            loc (Array): Means. Defaults to 0.
-            scale (Array): Standard deviations. Defaults to 1.
+            loc (ArrayLike): Means. Defaults to 0.
+            scale (ArrayLike): Standard deviations. Defaults to 1.
         """
         shape = jnp.broadcast_shapes(jnp.shape(loc), jnp.shape(scale))
         base_dist = StandardNormal(shape)
@@ -407,11 +405,11 @@ class Uniform(Transformed):
     def __init__(self, minval: ArrayLike, maxval: ArrayLike):
         """
         Args:
-            minval (Array): Minimum values.
-            maxval (Array): Maximum values.
+            minval (ArrayLike): Minimum values.
+            maxval (ArrayLike): Maximum values.
         """
-        shape = jnp.broadcast_shapes(jnp.shape(minval), jnp.shape(maxval))
-        minval, maxval = jnp.array(minval), jnp.array(maxval)
+        minval, maxval = jnp.asarray(minval), jnp.asarray(maxval)
+        shape = jnp.broadcast_shapes(minval.shape, maxval.shape)
         checkify.check(
             jnp.all(maxval >= minval),
             "Minimums must be less than the maximums.",
@@ -456,8 +454,8 @@ class Gumbel(Transformed):
         `loc` and `scale` should broadcast to the dimension of the distribution.
 
         Args:
-            loc (Array): Location paramter.
-            scale (Array): Scale parameter. Defaults to 1.0.
+            loc (ArrayLike): Location paramter.
+            scale (ArrayLike): Scale parameter. Defaults to 1.0.
         """
         shape = jnp.broadcast_shapes(jnp.shape(loc), jnp.shape(scale))
         base_dist = _StandardGumbel(shape)
@@ -503,8 +501,8 @@ class Cauchy(Transformed):
         `loc` and `scale` should broadcast to the dimension of the distribution.
 
         Args:
-            loc (Array): Location paramter.
-            scale (Array): Scale parameter. Defaults to 1.0.
+            loc (ArrayLike): Location paramter.
+            scale (ArrayLike): Scale parameter. Defaults to 1.0.
         """
         shape = jnp.broadcast_shapes(jnp.shape(loc), jnp.shape(scale))
         base_dist = _StandardCauchy(shape)
@@ -550,14 +548,14 @@ class StudentT(Transformed):
     bijection: Affine
     base_dist: _StandardStudentT
 
-    def __init__(self, df: Array, loc: ArrayLike = 0, scale: ArrayLike = 1):
+    def __init__(self, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1):
         """
         `df`, `loc` and `scale` broadcast to the dimension of the distribution.
 
         Args:
-            df (Array): The degrees of freedom.
-            loc (Array): Location parameter. Defaults to 0.0.
-            scale (Array): Scale parameter. Defaults to 1.0.
+            df (ArrayLike): The degrees of freedom.
+            loc (ArrayLike): Location parameter. Defaults to 0.0.
+            scale (ArrayLike): Scale parameter. Defaults to 1.0.
         """
         df, loc, scale = jnp.broadcast_arrays(df, loc, scale)
         base_dist = _StandardStudentT(df)

--- a/flowjax/distributions.py
+++ b/flowjax/distributions.py
@@ -70,7 +70,7 @@ class Distribution(eqx.Module):
     ) -> tuple[Array, Array]:
         """Sample a point from the distribution, and return its log probability.
         Subclasses can reimplement this method in cases where more efficient methods
-        exists (e.g. see Transformed).
+        exists (e.g. for :class:`Transformed` distributions).
         """
         x = self._sample(key, condition)
         log_prob = self._log_prob(x, condition)
@@ -108,9 +108,19 @@ class Distribution(eqx.Module):
         condition: ArrayLike | None = None,
     ) -> Array:
         """Sample from the distribution. For unconditional distributions, the output will
-        be of shape ``sample_shape + dist.shape``.
+        be of shape ``sample_shape + dist.shape``. For conditional distributions,
+        a batch dimension in the condition is supported, and the output shape will be
+        sample_shape + condition_batch_shape + dist.shape. See the example for more
+        information.
+
+        Args:
+            key (jr.KeyArray): Jax random key.
+            condition (ArrayLike | None): Conditioning variables. Defaults to None.
+            sample_shape (tuple[int, ...]): Sample shape. Defaults to ().
 
         Example:
+            The below example shows the behaviour of sampling, for an unconditional
+            and a conditional distribution.
 
             .. testsetup::
 
@@ -158,10 +168,6 @@ class Distribution(eqx.Module):
                 >>> samples.shape
                 (10, 5, 2)
 
-        Args:
-            key (jr.KeyArray): Jax random key.
-            condition (ArrayLike | None): Conditioning variables. Defaults to None.
-            sample_shape (tuple[int, ...]): Sample shape. Defaults to ().
 
         """
         condition = self._argcheck_and_cast_condition(condition)
@@ -179,11 +185,9 @@ class Distribution(eqx.Module):
     ):
         """Sample the distribution and return the samples and corresponding log probabilities.
         For transformed distributions (especially flows), this will generally be more efficient
-        than calling the methods seperately.
-
-        Refer to the :py:meth:`~flowjax.distributions.Distribution.sample` and
-        Refer to the :py:meth:`~flowjax.distributions.Distribution.log_prob` documentation
-        for more information.
+        than calling the methods seperately. Refer to the
+        :py:meth:`~flowjax.distributions.Distribution.sample` documentation for more
+        information.
 
         Args:
             key (jr.KeyArray): Jax random key.
@@ -333,7 +337,9 @@ class Transformed(Distribution):
 
 
 class StandardNormal(Distribution):
-    """Implements a standard normal distribution, condition is ignored."""
+    """Implements a standard normal distribution, condition is ignored. Unlike
+    :class:`Normal`, this has no trainable parameters.
+    """
 
     def __init__(self, shape: tuple[int, ...] = ()):
         """

--- a/flowjax/distributions.py
+++ b/flowjax/distributions.py
@@ -14,6 +14,8 @@ from jax.typing import ArrayLike
 from flowjax.bijections import Affine, Bijection
 from flowjax.utils import _get_ufunc_signature, merge_cond_shapes
 
+from flowjax.utils import arraylike_to_array
+
 
 class Distribution(eqx.Module):
     """Distribution base class. Distributions all have an attribute ``shape``,
@@ -227,9 +229,7 @@ class Distribution(eqx.Module):
         return keys
 
     def _argcheck_and_cast_x(self, x) -> Array:
-        if not isinstance(x, ArrayLike):
-            raise ValueError(f"Expected x to be arraylike; got {x}")
-        x = jnp.asarray(x)
+        x = arraylike_to_array(x, err_name="x")
         x_trailing = x.shape[-self.ndim :] if self.ndim > 0 else ()
         if x_trailing != self.shape:
             raise ValueError(
@@ -246,9 +246,7 @@ class Distribution(eqx.Module):
                     f"got {condition}."
                 )
             return None
-        if not isinstance(condition, ArrayLike):
-            raise ValueError(f"Expected condition to be arraylike; got {condition}")
-        condition = jnp.asarray(condition)
+        condition = arraylike_to_array(condition, err_name="condition")
         condition_trailing = (
             condition.shape[-len(self.cond_shape) :] if self.cond_ndim > 0 else ()  # type: ignore
         )
@@ -408,7 +406,7 @@ class Uniform(Transformed):
             minval (ArrayLike): Minimum values.
             maxval (ArrayLike): Maximum values.
         """
-        minval, maxval = jnp.asarray(minval), jnp.asarray(maxval)
+        minval, maxval = arraylike_to_array(minval), arraylike_to_array(maxval)
         shape = jnp.broadcast_shapes(minval.shape, maxval.shape)
         checkify.check(
             jnp.all(maxval >= minval),

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(filename):
 
 setup(
     name="flowjax",
-    version="9.0.0",
+    version="9.1.0",
     url="https://github.com/danielward27/flowjax.git",
     license="MIT",
     author="Daniel Ward",

--- a/tests/test_bijections/test_bijections.py
+++ b/tests/test_bijections/test_bijections.py
@@ -7,7 +7,6 @@ import pytest
 
 from flowjax.bijections import (
     AdditiveCondition,
-    AdditiveLinearCondition,
     Affine,
     BlockAutoregressiveNetwork,
     Chain,
@@ -102,9 +101,6 @@ bijections = {
     ),
     "BlockAutoregressiveNetwork (conditional)": BlockAutoregressiveNetwork(
         KEY, dim=DIM, cond_dim=COND_DIM, block_dim=3, depth=1
-    ),
-    "AdditiveLinearCondition": AdditiveLinearCondition(
-        jr.uniform(KEY, (DIM, COND_DIM))
     ),
     "AdditiveCondtition": AdditiveCondition(
         lambda condition: jnp.arange(DIM) * jnp.sum(condition), (DIM,), (COND_DIM,)

--- a/tests/test_bijections/test_bijections.py
+++ b/tests/test_bijections/test_bijections.py
@@ -6,6 +6,7 @@ import jax.random as jr
 import pytest
 
 from flowjax.bijections import (
+    AdditiveCondition,
     AdditiveLinearCondition,
     Affine,
     BlockAutoregressiveNetwork,
@@ -104,6 +105,9 @@ bijections = {
     ),
     "AdditiveLinearCondition": AdditiveLinearCondition(
         jr.uniform(KEY, (DIM, COND_DIM))
+    ),
+    "AdditiveCondtition": AdditiveCondition(
+        lambda condition: jnp.arange(DIM) * jnp.sum(condition), (DIM,), (COND_DIM,)
     ),
     "EmbedCondition": EmbedCondition(
         BlockAutoregressiveNetwork(KEY, dim=DIM, cond_dim=1, block_dim=3, depth=1),

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,5 +1,6 @@
 import jax.numpy as jnp
 import jax.random as jr
+import numpy as np
 import pytest
 
 from flowjax.distributions import (
@@ -47,7 +48,7 @@ def test_sample(distribution, shape):
     sample = d.sample(jr.PRNGKey(0))
     assert sample.shape == shape
 
-    sample_shape = (2, 2)
+    sample_shape = (1, 2)
     sample = d.sample(jr.PRNGKey(0), sample_shape)
     assert sample.shape == sample_shape + shape
 
@@ -60,9 +61,15 @@ def test_log_prob(distribution, shape):
 
     assert d.log_prob(x).shape == ()
 
-    sample_shape = (2, 3)
+    sample_shape = (1, 2)
     x = d.sample(jr.PRNGKey(0), sample_shape)
     assert d.log_prob(x).shape == sample_shape
+
+    # test arraylike input
+    assert jnp.all(d.log_prob(np.array(x)) == d.log_prob(x))
+
+    if d.shape == ():
+        assert d.log_prob(jnp.array(0)) == d.log_prob(0)
 
 
 @pytest.mark.parametrize("distribution", _test_distributions)


### PR DESCRIPTION
Changes:
- Allow ArrayLike inputs in bijections and distributions.
- Add utility function `arraylike_to_array` for checking inputs are `ArrayLike` and casting to array.
- Add `AdditiveCondition` bijection (a more flexible version of `AdditiveLinearCondition` and deprecate `AdditiveCondition`.
- Documentation improvements.

Breaking changes:
- Removal of `Distribution._argcheck`, replaced with `_argcheck_and_cast_x`, `_argcheck_and_cast_condition` methods, which also handle `ArrayLike` inputs.
- Removal of `Bijection._argcheck`, replaced with `_argcheck_and_cast` method which handles `ArrayLike` inputs.

As these are private methods, I have only bumped the minor version.