### PR TITLE
Stick the landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@ sudo apt-get install pandoc  # Required for building documentation
 
 ## Warning
 This package is new and may have substantial breaking changes between major releases.
+The API for distributions and bijections will be stable, but breaking changes to the
+losses and training procedures will be more common. 
 
 ## TODO
 A few limitations / things that could be worth including in the future:
 - Add ability to "reshape" bijections.
+- Add amortized variational inference.
 
 ## Related
 We make use of the [Equinox](https://arxiv.org/abs/2111.00254) package, which facilitates object-oriented programming with Jax. 

--- a/flowjax/train/data_fit.py
+++ b/flowjax/train/data_fit.py
@@ -9,7 +9,7 @@ from jax.typing import ArrayLike
 from tqdm import tqdm
 
 from flowjax.distributions import Distribution
-from flowjax.train.losses import Loss, MaximumLikelihoodLoss
+from flowjax.train.losses import MaximumLikelihoodLoss
 from flowjax.train.train_utils import (
     count_fruitless,
     get_batches,
@@ -25,7 +25,7 @@ def fit_to_data(
     dist: Distribution,
     x: ArrayLike,
     condition: ArrayLike = None,
-    loss_fn: Loss | None = None,
+    loss_fn: Callable | None = None,
     max_epochs: int = 100,
     max_patience: int = 5,
     batch_size: int = 100,
@@ -43,7 +43,7 @@ def fit_to_data(
         dist (Distribution): Distribution object.
         x (ArrayLike): Samples from target distribution.
         condition (ArrayLike | None): Conditioning variables. Defaults to None.
-        loss_fn (Loss | None): Loss function. Defaults to MaximumLikelihoodLoss.
+        loss_fn (Callable | None): Loss function. Defaults to MaximumLikelihoodLoss.
         max_epochs (int): Maximum number of epochs. Defaults to 100.
         max_patience (int): Number of consecutive epochs with no validation
             loss improvement after which training is terminated. Defaults to 5.

--- a/flowjax/train/losses.py
+++ b/flowjax/train/losses.py
@@ -132,4 +132,4 @@ class ElboLoss:
             samples, log_probs = dist.sample_and_log_prob(key, (self.num_samples,))
 
         target_density = vmap(self.target)(samples)
-        return log_probs.sum() - target_density.sum()
+        return (log_probs - target_density).mean()

--- a/flowjax/train/train_utils.py
+++ b/flowjax/train/train_utils.py
@@ -1,6 +1,6 @@
 """Utility functions for training."""
 from functools import partial
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -9,7 +9,6 @@ import optax
 from jax import Array, jit
 
 from flowjax.distributions import Distribution
-from flowjax.train.losses import Loss
 
 PyTree = Any
 
@@ -18,7 +17,7 @@ PyTree = Any
 def step(
     optimizer: optax.GradientTransformation,
     opt_state: PyTree,
-    loss_fn: Loss,
+    loss_fn: Callable,
     params: Distribution,
     *args,
     **kwargs,

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -7,7 +7,6 @@ import optax
 from tqdm import tqdm
 
 from flowjax.distributions import Distribution
-from flowjax.train.losses import Loss
 from flowjax.train.train_utils import step
 
 PyTree = Any
@@ -16,7 +15,7 @@ PyTree = Any
 def fit_to_variational_target(
     key: jr.KeyArray,
     dist: Distribution,
-    loss_fn: Loss,
+    loss_fn: Callable,
     steps: int = 100,
     learning_rate: float = 5e-4,
     optimizer: optax.GradientTransformation | None = None,
@@ -30,7 +29,7 @@ def fit_to_variational_target(
         key (jr.KeyArray): Jax PRNGKey.
         dist (Distribution): Distribution object, trainable parameters are found
             using equinox.is_inexact_array.
-        loss_fn (Loss | None): The loss function to optimize (e.g. the ElboLoss).
+        loss_fn (Callable | None): The loss function to optimize (e.g. the ElboLoss).
         steps (int, optional): The number of training steps to run. Defaults to 100.
         learning_rate (float, optional): Learning rate. Defaults to 5e-4.
         optimizer (optax.GradientTransformation | None, optional): Optax optimizer. If

--- a/tests/train/test_variational_fit.py
+++ b/tests/train/test_variational_fit.py
@@ -1,3 +1,4 @@
+import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
@@ -15,7 +16,7 @@ def test_elbo_loss(shape):
     target = StandardNormal(shape)
     vi_dist = StandardNormal(shape)
     loss = ElboLoss(target.log_prob, num_samples=100)
-    loss_val = loss.loss(vi_dist, jr.PRNGKey(0))
+    loss_val = loss(*eqx.partition(vi_dist, eqx.is_inexact_array), jr.PRNGKey(0))
     assert loss_val.shape == ()  # expect scalar loss
     assert jnp.isfinite(loss_val)  # expect finite loss
 


### PR DESCRIPTION
Adds two features:

- ``SpecializeCondition``, to specialise an ammortised conditional distribution to a particular conditioning instance
- ``stick_the_landing`` option in ELBO (a lower variance ELBO estimator) as outlined in https://arxiv.org/abs/1703.09194

Small breaking change:
- Losses are just Callables taking the partitioned model as the first two arguments (see eqx.partition), and we have dropped the ``Loss`` type for now 