### PR TITLE
Bnaf Issue

### DIFF
--- a/flowjax/bijections/__init__.py
+++ b/flowjax/bijections/__init__.py
@@ -12,7 +12,7 @@ from .masked_autoregressive import MaskedAutoregressive
 from .planar import Planar
 from .rational_quadratic_spline import RationalQuadraticSpline
 from .softplus import SoftPlus
-from .tanh import Tanh, TanhLinearTails
+from .tanh import LeakyTanh, Tanh, TanhLinearTails
 from .utils import EmbedCondition, Flip, Invert, Partial, Permute
 
 __all__ = [
@@ -37,6 +37,7 @@ __all__ = [
     "SoftPlus",
     "Stack",
     "Tanh",
+    "LeakyTanh",
     "TanhLinearTails",
     "TriangularAffine",
 ]

--- a/flowjax/flows.py
+++ b/flowjax/flows.py
@@ -181,7 +181,13 @@ class MaskedAutoregressiveFlow(Transformed):
 
 
 class BlockNeuralAutoregressiveFlow(Transformed):
-    """Block neural autoregressive flow (BNAF) (https://arxiv.org/abs/1904.04676)."""
+    """Block neural autoregressive flow (BNAF) (https://arxiv.org/abs/1904.04676).
+    Each flow layer contains a
+    :py:class:`~flowjax.bijections.block_autoregressive_network.BlockAutoregressiveNetwork`
+    bijection. The bijection does not have an analytic inverse, so either ``log_prob``
+    or ``sample`` and ``sample_and_log_prob`` will be unavailable, controlled using the
+    invert argument.
+    """
 
     flow_layers: int
     nn_block_dim: int
@@ -209,9 +215,10 @@ class BlockNeuralAutoregressiveFlow(Transformed):
             nn_block_dim (int): Block size. Hidden layer width is
                 dim*nn_block_dim. Defaults to 8.
             flow_layers (int): Number of BNAF layers. Defaults to 1.
-            invert: (bool): Use `True` for access of `log_prob` only (e.g.
+            invert: (bool): Use `True` for access of ``log_prob`` only (e.g.
                 fitting by maximum likelihood), `False` for the forward direction
-                (sampling) only (e.g. for fitting variationally).
+                (``sample`` and ``sample_and_log_prob``) only (e.g. for fitting
+                variationally).
             activation: (Bijection | Callable | None). Activation function used within
                 block neural autoregressive networks. Note this should be bijective and
                 in some use cases should map real -> real. For more information, see

--- a/flowjax/nn/__init__.py
+++ b/flowjax/nn/__init__.py
@@ -2,12 +2,11 @@
 neural networks).
 """
 
-from .block_autoregressive import BlockAutoregressiveLinear, _block_tanh_activation
+from .block_autoregressive import BlockAutoregressiveLinear
 from .masked_autoregressive import AutoregressiveMLP, MaskedLinear
 
 __all__ = [
     "MaskedLinear",
     "AutoregressiveMLP",
     "BlockAutoregressiveLinear",
-    "_block_tanh_activation",
 ]

--- a/tests/test_bijections/test_bnaf.py
+++ b/tests/test_bijections/test_bnaf.py
@@ -2,13 +2,8 @@ import jax
 import jax.numpy as jnp
 import pytest
 from jax import random
-from jax.scipy.linalg import block_diag
 
-from flowjax.bijections.block_autoregressive_network import (
-    BlockAutoregressiveNetwork,
-    _block_tanh_activation,
-)
-from flowjax.masks import block_diag_mask
+from flowjax.bijections.block_autoregressive_network import BlockAutoregressiveNetwork
 
 
 def test_BlockAutoregressiveNetwork():
@@ -35,17 +30,3 @@ def test_BlockAutoregressiveNetwork_conditioning():
     y1 = barn.transform(x, jnp.ones(cond_dim))
     y2 = barn.transform(x, jnp.zeros(cond_dim))
     assert jnp.all(y1 != y2)
-
-
-def test_block_tanh_activation():
-    n_blocks = 2
-    block_size = 3
-    x = random.uniform(random.PRNGKey(0), (n_blocks * block_size,))
-    tanh = _block_tanh_activation(n_blocks)
-
-    y, log_det_3d = tanh(x)
-    auto_jacobian = jax.jacobian(lambda a: tanh(a)[0])(x)
-    mask = block_diag_mask((block_size, block_size), n_blocks)
-    assert block_diag(*jnp.exp(log_det_3d)) == pytest.approx(
-        auto_jacobian * mask, abs=1e-7
-    )


### PR DESCRIPTION
Fixes #102, by using a LeakyTanh bijection, that defaults to a linear transform above or below max_val. Happy for more investigation/discussions, but this seems a reasonable fix for now.

Breaking changes:
- The activation for BlockAutoregressiveNetwork no longer needs a specific form, and instead can be any (potentially trainable) callable or scalar unconditional bijection.
- Renaming of TanhLinearTails to LeakyTanh could break users code (e.g. if subclassing TanhLinearTails, or explicitly relying on the class name).