### PR TITLE
Abstract var

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,11 @@ sudo apt-get install pandoc  # Required for building documentation
 ```
 
 ## Warning
-This package is new and may have substantial breaking changes between major releases.
-The API for distributions and bijections will be stable, but breaking changes to the
-losses and training procedures will be more common. 
+This package is in its early stages of development and may undergo significant changes, including breaking changes, between major releases. Whilst ideally we should be on version 0.y.z to indicate its state, we have already progressed beyond that stage.
 
 ## TODO
 A few limitations / things that could be worth including in the future:
 - Add ability to "reshape" bijections.
-- Add amortized variational inference.
 
 ## Related
 We make use of the [Equinox](https://arxiv.org/abs/2111.00254) package, which facilitates object-oriented programming with Jax. 

--- a/docs/api/distributions.rst
+++ b/docs/api/distributions.rst
@@ -4,5 +4,16 @@ Distributions from ``flowjax.distributions``.
 
 .. automodule:: flowjax.distributions
    :members:
-   :undoc-members:
    :show-inheritance:
+   :member-order: groupwise
+
+Implementing a custom distribution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To implement a custom distribution, subclass
+    -  :class:`~flowjax.distributions.AbstractStandardDistribution` for non-transformed distributions.
+    -  :class:`~flowjax.distributions.AbstractTransformed` for transformed distributions.
+
+For simple examples, check the source code for
+   - :class:`~flowjax.distributions.StandardNormal` as an example of an :class:`~flowjax.distributions.AbstractStandardDistribution`.
+   - :class:`~flowjax.distributions.Normal` as an example of an :class:`~flowjax.distributions.AbstractTransformed`.
+

--- a/docs/api/experimental.rst
+++ b/docs/api/experimental.rst
@@ -6,8 +6,9 @@ Interfacing with numpyro
 
 Supporting complex inference approaches such as MCMC or variational inference
 with arbitrary probabilistic models is out of the scope of this package. However, we do
-provide an (experimental) wrapper class, :class:`TransformedToNumpyro`, which will wrap
-a flowjax :class:`~flowjax.distributions.Transformed` distribution, into a 
+provide an (experimental) wrapper class,
+:class:`~flowjax.experimental.numpyro.TransformedToNumpyro`, which will wrap
+a flowjax :class:`~flowjax.distributions.AbstractTransformed` distribution, into a 
 `numpyro <https://github.com/pyro-ppl/numpyro>`_ distribution.
 This can be used for example to embed normalising flows into arbitrary
 probabilistic models. Here is a simple example

--- a/docs/api/experimental.rst
+++ b/docs/api/experimental.rst
@@ -1,6 +1,37 @@
 Experimental
 ==========================
 
+Interfacing with numpyro
+--------------------------
+
+Supporting complex inference approaches such as MCMC or variational inference
+with arbitrary probabilistic models is out of the scope of this package. However, we do
+provide an (experimental) wrapper class, :class:`TransformedToNumpyro`, which will wrap
+a flowjax :class:`~flowjax.distributions.Transformed` distribution, into a 
+`numpyro <https://github.com/pyro-ppl/numpyro>`_ distribution.
+This can be used for example to embed normalising flows into arbitrary
+probabilistic models. Here is a simple example
+
+    .. doctest::
+
+        >>> from numpyro.infer import MCMC, NUTS
+        >>> from flowjax.experimental.numpyro import TransformedToNumpyro
+        >>> from numpyro import sample
+        >>> from flowjax.distributions import Normal
+        >>> import jax.random as jr
+        >>> import numpy as np
+
+        >>> def numpyro_model(X, y):
+        ...     "Example regression model defined in terms of flowjax distributions"
+        ...     beta = sample("beta", TransformedToNumpyro(Normal(np.zeros(2))))
+        ...     sample("y", TransformedToNumpyro(Normal(X @ beta)), obs=y)
+
+        >>> X = np.random.randn(100, 2)
+        >>> beta_true = np.array([-1, 1])
+        >>> y = X @ beta_true + np.random.randn(100)
+        >>> mcmc = MCMC(NUTS(numpyro_model), num_warmup=10, num_samples=100)
+        >>> mcmc.run(jr.PRNGKey(0), X, y)
+
 .. automodule:: flowjax.experimental.numpyro
    :members:
    :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,9 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, Path.resolve(".."))
+import jax  # noqa Required to avoid circular import
+
+sys.path.insert(0, Path("..").resolve())
 
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,8 @@
 """Configuration file for the Sphinx documentation builder."""
-import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, Path.resolve(".."))
 
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,6 @@
-# Configuration file for the Sphinx documentation builder.
+"""Configuration file for the Sphinx documentation builder."""
 import os
 import sys
-
-import jax  # noqa Avoid circular import
-
-# Avoid unused module linting
 
 sys.path.insert(0, os.path.abspath(".."))
 

--- a/docs/examples/bounded.ipynb
+++ b/docs/examples/bounded.ipynb
@@ -31,6 +31,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,6 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -81,6 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -100,10 +103,10 @@
     "preprocess = Chain(\n",
     "    [\n",
     "        Affine(\n",
-    "            loc=-jnp.ones(2) + eps, scale=(1 - eps) * jnp.array([2, 2])\n",
+    "            loc=-jnp.ones(2) + eps, scale=(1 - eps) * jnp.array([2, 2]),\n",
     "        ),  # [-1+eps, 1-eps]\n",
     "        Invert(Tanh(shape=(2,))),  # arctanh (to unbounded)\n",
-    "    ]\n",
+    "    ],\n",
     ")\n",
     "\n",
     "x_preprocessed = jax.vmap(preprocess.transform)(x)\n",
@@ -128,6 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -175,6 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -194,7 +199,7 @@
    ],
    "source": [
     "naive_flow, losses = fit_to_data(\n",
-    "    subkey, untrained_flow, x, learning_rate=5e-3, max_patience=10, max_epochs=70\n",
+    "    subkey, untrained_flow, x, learning_rate=5e-3, max_patience=10, max_epochs=70,\n",
     ")"
    ]
   },
@@ -209,6 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -245,6 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": null,
    "metadata": {},
    "outputs": [],
    "source": []

--- a/docs/examples/bounded.ipynb
+++ b/docs/examples/bounded.ipynb
@@ -35,14 +35,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import jax.random as jr\n",
-    "import jax.numpy as jnp\n",
     "import jax\n",
-    "from flowjax.flows import MaskedAutoregressiveFlow\n",
+    "import jax.numpy as jnp\n",
+    "import jax.random as jr\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from flowjax.bijections import Affine, Chain, Invert, Tanh\n",
     "from flowjax.distributions import Normal, Transformed\n",
-    "from flowjax.bijections import Tanh, Affine, Chain, Invert\n",
-    "from flowjax.train import fit_to_data\n",
-    "import matplotlib.pyplot as plt"
+    "from flowjax.flows import MaskedAutoregressiveFlow\n",
+    "from flowjax.train import fit_to_data"
    ]
   },
   {

--- a/docs/examples/conditional.ipynb
+++ b/docs/examples/conditional.ipynb
@@ -31,12 +31,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import jax.random as jr\n",
     "import jax.numpy as jnp\n",
-    "from flowjax.flows import BlockNeuralAutoregressiveFlow\n",
+    "import jax.random as jr\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
     "from flowjax.distributions import Normal\n",
-    "from flowjax.train import fit_to_data\n",
-    "import matplotlib.pyplot as plt"
+    "from flowjax.flows import BlockNeuralAutoregressiveFlow\n",
+    "from flowjax.train import fit_to_data"
    ]
   },
   {

--- a/docs/examples/conditional.ipynb
+++ b/docs/examples/conditional.ipynb
@@ -139,7 +139,7 @@
     "test_u = jnp.array([1.0, 3])\n",
     "\n",
     "xgrid, ygrid = jnp.meshgrid(\n",
-    "    jnp.linspace(-1, 4, resolution), jnp.linspace(-1, 4, resolution)\n",
+    "    jnp.linspace(-1, 4, resolution), jnp.linspace(-1, 4, resolution),\n",
     ")\n",
     "xyinput = jnp.column_stack((xgrid.reshape(-1, 1), ygrid.reshape(-1, 1)))\n",
     "zgrid = jnp.exp(flow.log_prob(xyinput, test_u).reshape(resolution, resolution))\n",

--- a/docs/examples/snpe.ipynb
+++ b/docs/examples/snpe.ipynb
@@ -21,19 +21,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import equinox as eqx\n",
     "import jax.numpy as jnp\n",
     "import jax.random as jr\n",
     "import matplotlib.pyplot as plt\n",
-    "import equinox as eqx\n",
-    "\n",
     "from jax import vmap\n",
     "\n",
-    "from flowjax.train.data_fit import fit_to_data\n",
-    "from flowjax.train.losses import ContrastiveLoss\n",
-    "from flowjax.flows import MaskedAutoregressiveFlow\n",
-    "from flowjax.distributions import Normal, Transformed\n",
     "import flowjax.bijections as bij\n",
-    "from flowjax.tasks import GaussianMixtureSimulator"
+    "from flowjax.distributions import Normal, Transformed\n",
+    "from flowjax.flows import MaskedAutoregressiveFlow\n",
+    "from flowjax.tasks import GaussianMixtureSimulator\n",
+    "from flowjax.train.data_fit import fit_to_data\n",
+    "from flowjax.train.losses import ContrastiveLoss"
    ]
   },
   {

--- a/docs/examples/snpe.ipynb
+++ b/docs/examples/snpe.ipynb
@@ -17,6 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,6 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -77,6 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,6 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +110,7 @@
     "    [\n",
     "        bij.Affine(jnp.zeros(task.dim), 1 / task.prior_bound),  # to [-1, 1]\n",
     "        bij.Invert(bij.Tanh((task.dim,))),  # Arctanh (to unbounded)\n",
-    "    ]\n",
+    "    ],\n",
     ")\n",
     "\n",
     "unbounded_prior = Transformed(task.prior, to_unbounded)"
@@ -122,6 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -148,7 +153,7 @@
     "        theta_r = unbounded_prior.sample(subkey, (sim_per_round,))\n",
     "    else:\n",
     "        theta_r = eqx.filter_jit(proposal.sample)(\n",
-    "            subkey, (sim_per_round,), condition=observed\n",
+    "            subkey, (sim_per_round,), condition=observed,\n",
     "        )\n",
     "\n",
     "    key, subkey = jr.split(key)\n",
@@ -183,6 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,14 +200,15 @@
     "key, subkey = jr.split(key)\n",
     "data[\"theta\"].append(\n",
     "    posterior.sample(\n",
-    "        subkey, (sim_per_round,), condition=observed\n",
-    "    )\n",
+    "        subkey, (sim_per_round,), condition=observed,\n",
+    "    ),\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -247,6 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": null,
    "metadata": {},
    "outputs": [],
    "source": []

--- a/docs/examples/unconditional.ipynb
+++ b/docs/examples/unconditional.ipynb
@@ -22,17 +22,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import jax.numpy as jnp\n",
     "import jax.random as jr\n",
-    "from flowjax.flows import MaskedAutoregressiveFlow\n",
-    "from flowjax.train import fit_to_data\n",
-    "from flowjax.distributions import Normal\n",
-    "from flowjax.bijections import RationalQuadraticSpline\n",
     "import matplotlib.pyplot as plt\n",
-    "from flowjax.tasks import two_moons"
+    "\n",
+    "from flowjax.bijections import RationalQuadraticSpline\n",
+    "from flowjax.distributions import Normal\n",
+    "from flowjax.flows import MaskedAutoregressiveFlow\n",
+    "from flowjax.tasks import two_moons\n",
+    "from flowjax.train import fit_to_data"
    ]
   },
   {
@@ -46,6 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -74,6 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,6 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -123,6 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -152,6 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -190,6 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": null,
    "metadata": {},
    "outputs": [],
    "source": []

--- a/docs/examples/variational_inference.ipynb
+++ b/docs/examples/variational_inference.ipynb
@@ -15,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -27,15 +26,16 @@
     }
    ],
    "source": [
-    "import jax.random as jr\n",
     "import jax.numpy as jnp\n",
+    "import jax.random as jr\n",
     "import matplotlib.pyplot as plt\n",
-    "from jax.scipy.stats import norm, multivariate_normal\n",
-    "from flowjax.flows import MaskedAutoregressiveFlow\n",
+    "from jax.scipy.stats import multivariate_normal, norm\n",
+    "\n",
     "from flowjax.bijections import Affine\n",
     "from flowjax.distributions import StandardNormal\n",
-    "from flowjax.train.variational_fit import fit_to_variational_target\n",
+    "from flowjax.flows import MaskedAutoregressiveFlow\n",
     "from flowjax.train.losses import ElboLoss\n",
+    "from flowjax.train.variational_fit import fit_to_variational_target\n",
     "\n",
     "# generate observed data\n",
     "data_key = jr.PRNGKey(0)\n",
@@ -59,7 +59,6 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +79,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -116,7 +114,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -146,9 +143,9 @@
     "):\n",
     "    xvalues = jnp.linspace(xmin, xmax, n)\n",
     "    yvalues = jnp.linspace(ymin, ymax, n)\n",
-    "    X, Y = jnp.meshgrid(xvalues, yvalues)\n",
+    "    x, y = jnp.meshgrid(xvalues, yvalues)\n",
     "\n",
-    "    points = jnp.hstack([X.reshape(-1, 1), Y.reshape(-1, 1)])\n",
+    "    points = jnp.hstack([x.reshape(-1, 1), y.reshape(-1, 1)])\n",
     "\n",
     "    log_prob = density_fn(points).reshape(n, n)\n",
     "    prob = jnp.exp(log_prob)\n",
@@ -164,7 +161,7 @@
     "fig, axes = plt.subplots(ncols=2, figsize=(9, 3))\n",
     "axes[0].set_title(\"Density plot\")\n",
     "\n",
-    "kwargs = dict(xmin=0.25, xmax=1.25, ymin=-1, ymax=0, levels=5)\n",
+    "kwargs = {\"xmin\": 0.25, \"xmax\": 1.25, \"ymin\": -1, \"ymax\": 0, \"levels\": 5}\n",
     "plot_density(axes[0], flow.log_prob, cmap=\"Blues\", **kwargs)\n",
     "\n",
     "# True posterior for comparison\n",
@@ -192,7 +189,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -231,7 +227,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": null,
    "metadata": {},
    "outputs": [],
    "source": []

--- a/docs/examples/variational_inference.ipynb
+++ b/docs/examples/variational_inference.ipynb
@@ -15,6 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -58,6 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,6 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -93,12 +96,12 @@
     "\n",
     "key, flow_key, train_key = jr.split(key, 3)\n",
     "flow = MaskedAutoregressiveFlow(\n",
-    "    flow_key, base_dist=StandardNormal((2,)), transformer=Affine(), invert=False\n",
+    "    flow_key, base_dist=StandardNormal((2,)), transformer=Affine(), invert=False,\n",
     ")\n",
     "\n",
     "# Train the flow variationally\n",
     "flow, losses = fit_to_variational_target(\n",
-    "    train_key, flow, loss, learning_rate=1e-3, steps=200\n",
+    "    train_key, flow, loss, learning_rate=1e-3, steps=200,\n",
     ")"
    ]
   },
@@ -113,6 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -138,7 +142,7 @@
    ],
    "source": [
     "def plot_density(\n",
-    "    ax, density_fn, xmin=-5, xmax=5, ymin=-5, ymax=5, n=100, levels=None, cmap=\"Blues\"\n",
+    "    ax, density_fn, xmin=-5, xmax=5, ymin=-5, ymax=5, n=100, levels=None, cmap=\"Blues\",\n",
     "):\n",
     "    xvalues = jnp.linspace(xmin, xmax, n)\n",
     "    yvalues = jnp.linspace(ymin, ymax, n)\n",
@@ -150,7 +154,7 @@
     "    prob = jnp.exp(log_prob)\n",
     "\n",
     "    ax.contour(\n",
-    "        prob, levels=levels, extent=[xmin, xmax, ymin, ymax], origin=\"lower\", cmap=cmap\n",
+    "        prob, levels=levels, extent=[xmin, xmax, ymin, ymax], origin=\"lower\", cmap=cmap,\n",
     "    )\n",
     "\n",
     "    ax.set_xlim(xmin, xmax)\n",
@@ -188,6 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": null,
    "metadata": {},
    "outputs": [
     {
@@ -226,6 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": null,
    "metadata": {},
    "outputs": [],
    "source": []

--- a/flowjax/bijections/__init__.py
+++ b/flowjax/bijections/__init__.py
@@ -7,7 +7,7 @@ from .chain import Chain
 from .concatenate import Concatenate, Stack
 from .coupling import Coupling
 from .exp import Exp
-from .jax_transforms import Batch, Scan
+from .jax_transforms import Scan, Vmap
 from .masked_autoregressive import MaskedAutoregressive
 from .planar import Planar
 from .rational_quadratic_spline import RationalQuadraticSpline
@@ -19,7 +19,7 @@ __all__ = [
     "AdditiveCondition",
     "Affine",
     "AbstractBijection",
-    "Batch",
+    "Vmap",
     "BlockAutoregressiveNetwork",
     "Chain",
     "Concatenate",

--- a/flowjax/bijections/__init__.py
+++ b/flowjax/bijections/__init__.py
@@ -1,7 +1,7 @@
 """Bijections from ``flowjax.bijections``"""
 
 from .affine import AdditiveCondition, Affine, TriangularAffine
-from .bijection import Bijection
+from .bijection import AbstractBijection
 from .block_autoregressive_network import BlockAutoregressiveNetwork
 from .chain import Chain
 from .concatenate import Concatenate, Stack
@@ -18,8 +18,8 @@ from .utils import EmbedCondition, Flip, Invert, Partial, Permute
 __all__ = [
     "AdditiveCondition",
     "Affine",
+    "AbstractBijection",
     "Batch",
-    "Bijection",
     "BlockAutoregressiveNetwork",
     "Chain",
     "Concatenate",

--- a/flowjax/bijections/__init__.py
+++ b/flowjax/bijections/__init__.py
@@ -1,4 +1,4 @@
-"""Bijections from ``flowjax.bijections``"""
+"""Bijections from ``flowjax.bijections``."""
 
 from .affine import AdditiveCondition, Affine, TriangularAffine
 from .bijection import AbstractBijection

--- a/flowjax/bijections/__init__.py
+++ b/flowjax/bijections/__init__.py
@@ -12,7 +12,7 @@ from .masked_autoregressive import MaskedAutoregressive
 from .planar import Planar
 from .rational_quadratic_spline import RationalQuadraticSpline
 from .softplus import SoftPlus
-from .tanh import LeakyTanh, Tanh, TanhLinearTails
+from .tanh import LeakyTanh, Tanh
 from .utils import EmbedCondition, Flip, Invert, Partial, Permute
 
 __all__ = [
@@ -38,6 +38,5 @@ __all__ = [
     "Stack",
     "Tanh",
     "LeakyTanh",
-    "TanhLinearTails",
     "TriangularAffine",
 ]

--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -34,7 +34,7 @@ class Affine(AbstractBijection):
         Args:
             loc (ArrayLike): Location parameter. Defaults to 0.
             scale (ArrayLike): Scale parameter. Defaults to 1.
-            postivity_constraint (Bijection): Bijection with shape matching the Affine
+            postivity_constraint (AbstractBijection): Bijection with shape matching the Affine
                 bijection, that maps the scale parameter from an unbounded domain to the
                 positive domain. Defaults to SoftPlus.
         """
@@ -101,7 +101,7 @@ class TriangularAffine(AbstractBijection):
             lower (bool): Whether the mask should select the lower or upper
                 triangular matrix (other elements ignored). Defaults to True (lower).
             weight_normalisation (bool): If true, carry out weight normalisation.
-            postivity_constraint (Bijection): Bijection with shape matching the
+            postivity_constraint (AbstractBijection): Bijection with shape matching the
                 dimension of the triangular affine bijection, that maps the diagonal
                 entries of the array from an unbounded domain to the positive domain.
                 Also used for weight normalisation parameters, if used. Defaults to

--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -1,6 +1,7 @@
 """Affine bijections."""
 
-from typing import Callable, ClassVar
+from collections.abc import Callable
+from typing import ClassVar
 
 import jax.numpy as jnp
 from jax import Array
@@ -39,7 +40,7 @@ class Affine(AbstractBijection):
                 matching the Affine bijection, that maps the scale parameter from an
                 unbounded domain to the positive domain. Defaults to SoftPlus.
         """
-        loc, scale = [arraylike_to_array(a, dtype=float) for a in (loc, scale)]
+        loc, scale = (arraylike_to_array(a, dtype=float) for a in (loc, scale))
         self.shape = jnp.broadcast_shapes(loc.shape, scale.shape)
         self.loc = jnp.broadcast_to(loc, self.shape)
 
@@ -112,7 +113,7 @@ class TriangularAffine(AbstractBijection):
                 Also used for weight normalisation parameters, if used. Defaults to
                 SoftPlus.
         """
-        loc, arr = [arraylike_to_array(a, dtype=float) for a in (loc, arr)]
+        loc, arr = (arraylike_to_array(a, dtype=float) for a in (loc, arr))
         if (arr.ndim != 2) or (arr.shape[0] != arr.shape[1]):
             raise ValueError("arr must be a square, 2-dimensional matrix.")
         checkify.check(
@@ -236,7 +237,7 @@ class AdditiveCondition(AbstractBijection):
 
     def inverse(self, y, condition=None):
         y, condition = self._argcheck_and_cast(y, condition)
-        return y - self.module(condition)  # type: ignore
+        return y - self.module(condition)
 
     def inverse_and_log_det(self, y, condition=None):
         y, condition = self._argcheck_and_cast(y, condition)

--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -13,7 +13,7 @@ from flowjax.bijections.softplus import SoftPlus
 from flowjax.utils import arraylike_to_array
 
 
-class Affine(AbstractBijection, strict=True):
+class Affine(AbstractBijection):
     """Elementwise affine transformation ``y = a*x + b``. loc and scale should broadcast
     to the desired shape of the bijection.
     """
@@ -72,7 +72,7 @@ class Affine(AbstractBijection, strict=True):
         return self.positivity_constraint.transform(self._scale)
 
 
-class TriangularAffine(AbstractBijection, strict=True):
+class TriangularAffine(AbstractBijection):
     r"""Transformation of the form :math:`Ax + b`, where :math:`A` is a lower or upper
     triangular matrix."""
     shape: tuple[int, ...]
@@ -172,7 +172,7 @@ class TriangularAffine(AbstractBijection, strict=True):
         return x, -jnp.log(jnp.diag(arr)).sum()
 
 
-class AdditiveCondition(AbstractBijection, strict=True):
+class AdditiveCondition(AbstractBijection):
     """Given a callable ``f``, carries out ``y = x + f(condition)`` as the forward
     transformation and ``x = y - f(condition)`` as the inverse transformation. Note that
     the callable can be a callable module with trainable parameters if desired.
@@ -220,7 +220,7 @@ class AdditiveCondition(AbstractBijection, strict=True):
 
     def transform(self, x, condition=None):
         x, condition = self._argcheck_and_cast(x, condition)
-        return x + self.module(condition)  # type: ignore - validated in argcheck
+        return x + self.module(condition)
 
     def transform_and_log_det(self, x, condition=None):
         x, condition = self._argcheck_and_cast(x, condition)
@@ -232,4 +232,4 @@ class AdditiveCondition(AbstractBijection, strict=True):
 
     def inverse_and_log_det(self, y, condition=None):
         y, condition = self._argcheck_and_cast(y, condition)
-        return self.inverse(y, condition), jnp.array(0)  # type: ignore
+        return self.inverse(y, condition), jnp.array(0)

--- a/flowjax/bijections/bijection.py
+++ b/flowjax/bijections/bijection.py
@@ -46,25 +46,39 @@ class AbstractBijection(Module):  # TODO update documentation
 
     @abstractmethod
     def transform(self, x: ArrayLike, condition: ArrayLike | None = None) -> Array:
-        """Apply transformation."""
+        """Apply transformation to an input with shape matching bijection.shape."""
 
     @abstractmethod
     def transform_and_log_det(
         self, x: ArrayLike, condition: ArrayLike | None = None
     ) -> tuple[Array, Array]:
-        """Apply transformation and compute log absolute value of the Jacobian
-        determinant."""
+        """Apply transformation to an input with shape matching bijection.shape,
+        and compute log absolute value of the Jacobian determinant."""
 
     @abstractmethod
     def inverse(self, y: ArrayLike, condition: ArrayLike | None = None) -> Array:
-        """Invert the transformation."""
+        """Compute the inverse transformation.
+
+        Args:
+            y (ArrayLike): Input array with shape matching bijection.shape
+            condition (ArrayLike | None, optional): Condition array with shape matching
+                bijection.cond_shape. Required for conditional bijections. Defaults to
+                None.
+        """
 
     @abstractmethod
     def inverse_and_log_det(
         self, y: ArrayLike, condition: ArrayLike | None = None
     ) -> tuple[Array, Array]:
-        """Invert the transformation and compute log absolute value of the Jacobian
-        determinant."""
+        """Compute the inverse transformation, and return the log absolute value of
+        the jacobian determinant of the inverse transformation.
+
+        Args:
+            y (ArrayLike): Input array with shape matching bijection.shape.
+            condition (ArrayLike | None, optional): Condition array with shape matching
+                bijection.cond_shape. Required for conditional bijections. Defaults to
+                None.
+        """
 
     def _argcheck_and_cast(
         self, x: ArrayLike, condition: ArrayLike | None = None

--- a/flowjax/bijections/bijection.py
+++ b/flowjax/bijections/bijection.py
@@ -8,18 +8,18 @@ fitting of flows).
 
 from abc import abstractmethod
 
-from equinox import Module
+from equinox import AbstractVar, Module
 from jax import Array
 from jax.typing import ArrayLike
 
 from flowjax.utils import arraylike_to_array
 
 
-class Bijection(Module):
-    """Bijection base class. Similar to :py:class:`~flowjax.distributions.Distribution`,
-    bijections have a ``shape`` and a ``cond_shape`` attribute. To allow easy composing
-    of bijections, all bijections support passing of conditioning variables (even if
-    ignored).
+class AbstractBijection(Module, strict=True):  # TODO update documentation
+    """Bijection abstract class. Similar to
+    :py:class:`~flowjax.distributions.Distribution`, bijections have a ``shape`` and a
+    ``cond_shape`` attribute. To allow easy composing of bijections, all bijections
+    support passing of conditioning variables (even if ignored).
 
     The methods of bijections do not generally support passing of additional batch
     dimensions, however, ``jax.vmap`` or ``eqx.filter_vmap`` can be used to vmap
@@ -31,7 +31,7 @@ class Bijection(Module):
 
     **Implementing a bijection**
 
-        (1) Inherit from ``Bijection``.
+        (1) Inherit from ``AbstractBijection``.
         (2) Define the attributes ``shape`` and ``cond_shape``. A ``cond_shape`` of
             ``None`` is used to represent unconditional bijections.
         (3) Implement the abstract methods ``transform``, ``transform_and_log_det``,
@@ -41,8 +41,8 @@ class Bijection(Module):
 
     """
 
-    shape: tuple[int, ...]
-    cond_shape: tuple[int, ...] | None
+    shape: AbstractVar[tuple[int, ...]]
+    cond_shape: AbstractVar[tuple[int, ...] | None]
 
     @abstractmethod
     def transform(self, x: ArrayLike, condition: ArrayLike | None = None) -> Array:

--- a/flowjax/bijections/bijection.py
+++ b/flowjax/bijections/bijection.py
@@ -1,9 +1,10 @@
-"""Abstact base classes for the `Bijection` and `Bijection` types. Note when
-implementing bijections, by convention we try to i) implement the "transform" methods as
-the faster/more intuitive approach (compared to the inverse methods); and ii) implement
-only the forward methods if an inverse is not available. The `Invert` bijection can be
-used to invert the orientation if a fast inverse is desired (e.g. maximum likelihood
-fitting of flows).
+"""Abstact base classes for the `Bijection` and `Bijection` types.
+
+Note when implementing bijections, by convention we try to i) implement the "transform"
+methods as the faster/more intuitive approach (compared to the inverse methods); and ii)
+implement only the forward methods if an inverse is not available. The `Invert`
+bijection can be used to invert the orientation if a fast inverse is desired (e.g.
+maximum likelihood fitting of flows).
 """
 
 from abc import abstractmethod
@@ -15,11 +16,12 @@ from jax.typing import ArrayLike
 from flowjax.utils import arraylike_to_array
 
 
-class AbstractBijection(Module):  # TODO update documentation
-    """Bijection abstract class. Similar to
-    :py:class:`~flowjax.distributions.Distribution`, bijections have a ``shape`` and a
-    ``cond_shape`` attribute. To allow easy composing of bijections, all bijections
-    support passing of conditioning variables (even if ignored).
+class AbstractBijection(Module):
+    """Bijection abstract class.
+
+    Similar to :py:class:`~flowjax.distributions.AbstractDistribution`, bijections have
+    a ``shape`` and a ``cond_shape`` attribute. To allow easy composing of bijections,
+    all bijections support passing of conditioning variables (even if ignored).
 
     The methods of bijections do not generally support passing of additional batch
     dimensions, however, ``jax.vmap`` or ``eqx.filter_vmap`` can be used to vmap
@@ -38,7 +40,6 @@ class AbstractBijection(Module):  # TODO update documentation
             ``inverse`` and ``inverse_and_log_det``. These should act on
             inputs compatible with the shapes ``shape`` for ``x``, and ``cond_shape``
             for ``condition``.
-
     """
 
     shape: AbstractVar[tuple[int, ...]]
@@ -46,14 +47,32 @@ class AbstractBijection(Module):  # TODO update documentation
 
     @abstractmethod
     def transform(self, x: ArrayLike, condition: ArrayLike | None = None) -> Array:
-        """Apply transformation to an input with shape matching bijection.shape."""
+        """Apply the forward transformation.
+
+        Args:
+            x (ArrayLike): Input with shape matching bijections.shape.
+            condition (ArrayLike | None, optional): Condition, with shape matching
+                bijection.cond_shape, required for conditional bijections. Defaults to
+                None.
+        """
 
     @abstractmethod
     def transform_and_log_det(
         self, x: ArrayLike, condition: ArrayLike | None = None
     ) -> tuple[Array, Array]:
-        """Apply transformation to an input with shape matching bijection.shape,
-        and compute log absolute value of the Jacobian determinant."""
+        """Apply transformation and compute the log absolute Jacobian determinant.
+
+        Args:
+            x (ArrayLike): Input with shape matching the bijections shape
+            condition (ArrayLike | None, optional): . Defaults to None.
+
+        Raises:
+            ValueError: _description_
+            ValueError: _description_
+
+        Returns:
+            tuple[Array, Array]: _description_
+        """
 
     @abstractmethod
     def inverse(self, y: ArrayLike, condition: ArrayLike | None = None) -> Array:
@@ -70,8 +89,7 @@ class AbstractBijection(Module):  # TODO update documentation
     def inverse_and_log_det(
         self, y: ArrayLike, condition: ArrayLike | None = None
     ) -> tuple[Array, Array]:
-        """Compute the inverse transformation, and return the log absolute value of
-        the jacobian determinant of the inverse transformation.
+        """Inverse transformation and corresponding log absolute jacobian determinant.
 
         Args:
             y (ArrayLike): Input array with shape matching bijection.shape.
@@ -83,9 +101,10 @@ class AbstractBijection(Module):  # TODO update documentation
     def _argcheck_and_cast(
         self, x: ArrayLike, condition: ArrayLike | None = None
     ) -> tuple[Array, Array | None]:
-        """Utility function that checks input shapes against the bijection shapes,
-        and casts inputs to arrays if required. Note this permits passing a condition
-        in the case when bijection.cond_shape is None."""
+        """Utility method to check input shapes and cast inputs to arrays if required.
+
+        Note this permits passing a condition array to unconditional distributions.
+        """
         x = arraylike_to_array(x, err_name="x")
 
         if x.shape != self.shape:

--- a/flowjax/bijections/bijection.py
+++ b/flowjax/bijections/bijection.py
@@ -15,7 +15,7 @@ from jax.typing import ArrayLike
 from flowjax.utils import arraylike_to_array
 
 
-class AbstractBijection(Module, strict=True):  # TODO update documentation
+class AbstractBijection(Module):  # TODO update documentation
     """Bijection abstract class. Similar to
     :py:class:`~flowjax.distributions.Distribution`, bijections have a ``shape`` and a
     ``cond_shape`` attribute. To allow easy composing of bijections, all bijections
@@ -24,7 +24,7 @@ class AbstractBijection(Module, strict=True):  # TODO update documentation
     The methods of bijections do not generally support passing of additional batch
     dimensions, however, ``jax.vmap`` or ``eqx.filter_vmap`` can be used to vmap
     specific methods if desired, and a bijection can be explicitly vectorised using the
-    :py:class:`~flowjax.bijections.jax_transforms.Batch` bijection.
+    :py:class:`~flowjax.bijections.jax_transforms.Vmap` bijection.
 
     Bijections are registered as Jax PyTrees (as they are equinox modules), so are
     compatible with normal jax operations.

--- a/flowjax/bijections/bijection.py
+++ b/flowjax/bijections/bijection.py
@@ -58,7 +58,7 @@ class AbstractBijection(Module):
 
     @abstractmethod
     def transform_and_log_det(
-        self, x: ArrayLike, condition: ArrayLike | None = None
+        self, x: ArrayLike, condition: ArrayLike | None = None,
     ) -> tuple[Array, Array]:
         """Apply transformation and compute the log absolute Jacobian determinant.
 
@@ -87,7 +87,7 @@ class AbstractBijection(Module):
 
     @abstractmethod
     def inverse_and_log_det(
-        self, y: ArrayLike, condition: ArrayLike | None = None
+        self, y: ArrayLike, condition: ArrayLike | None = None,
     ) -> tuple[Array, Array]:
         """Inverse transformation and corresponding log absolute jacobian determinant.
 
@@ -99,7 +99,7 @@ class AbstractBijection(Module):
         """
 
     def _argcheck_and_cast(
-        self, x: ArrayLike, condition: ArrayLike | None = None
+        self, x: ArrayLike, condition: ArrayLike | None = None,
     ) -> tuple[Array, Array | None]:
         """Utility method to check input shapes and cast inputs to arrays if required.
 
@@ -115,7 +115,8 @@ class AbstractBijection(Module):
 
             if self.cond_shape is not None and condition.shape != self.cond_shape:
                 raise ValueError(
-                    f"Expected condition.shape {self.cond_shape}; got {condition.shape}"
+                    f"Expected condition.shape {self.cond_shape}; got "
+                    f"{condition.shape}",
                 )
 
         return x, condition

--- a/flowjax/bijections/bijection.py
+++ b/flowjax/bijections/bijection.py
@@ -26,7 +26,7 @@ class AbstractBijection(Module):
     The methods of bijections do not generally support passing of additional batch
     dimensions, however, ``jax.vmap`` or ``eqx.filter_vmap`` can be used to vmap
     specific methods if desired, and a bijection can be explicitly vectorised using the
-    :class:`~flowjax.bijections.jax_transforms.Batch` bijection.
+    :class:`~flowjax.bijections.jax_transforms.Vmap` bijection.
 
     Bijections are registered as Jax PyTrees (as they are equinox modules), so are
     compatible with normal jax operations.
@@ -58,7 +58,9 @@ class AbstractBijection(Module):
 
     @abstractmethod
     def transform_and_log_det(
-        self, x: ArrayLike, condition: ArrayLike | None = None,
+        self,
+        x: ArrayLike,
+        condition: ArrayLike | None = None,
     ) -> tuple[Array, Array]:
         """Apply transformation and compute the log absolute Jacobian determinant.
 
@@ -87,7 +89,9 @@ class AbstractBijection(Module):
 
     @abstractmethod
     def inverse_and_log_det(
-        self, y: ArrayLike, condition: ArrayLike | None = None,
+        self,
+        y: ArrayLike,
+        condition: ArrayLike | None = None,
     ) -> tuple[Array, Array]:
         """Inverse transformation and corresponding log absolute jacobian determinant.
 
@@ -99,7 +103,9 @@ class AbstractBijection(Module):
         """
 
     def _argcheck_and_cast(
-        self, x: ArrayLike, condition: ArrayLike | None = None,
+        self,
+        x: ArrayLike,
+        condition: ArrayLike | None = None,
     ) -> tuple[Array, Array | None]:
         """Utility method to check input shapes and cast inputs to arrays if required.
 

--- a/flowjax/bijections/block_autoregressive_network.py
+++ b/flowjax/bijections/block_autoregressive_network.py
@@ -101,10 +101,10 @@ class BlockAutoregressiveNetwork(AbstractBijection):
             cond_dims = [cond_dim] + [None] * depth
 
             for layer_key, block_shape, cond_d in zip(
-                keys, block_shapes, cond_dims, strict=True
+                keys, block_shapes, cond_dims, strict=True,
             ):
                 layers.append(
-                    BlockAutoregressiveLinear(layer_key, dim, block_shape, cond_d)
+                    BlockAutoregressiveLinear(layer_key, dim, block_shape, cond_d),
                 )
 
         self.depth = depth
@@ -143,12 +143,12 @@ class BlockAutoregressiveNetwork(AbstractBijection):
 
     def inverse(self, *args, **kwargs):
         raise NotImplementedError(
-            "This transform would require numerical methods for inversion."
+            "This transform would require numerical methods for inversion.",
         )
 
     def inverse_and_log_det(self, *args, **kwargs):
         raise NotImplementedError(
-            "This transform would require numerical methods for inversion."
+            "This transform would require numerical methods for inversion.",
         )
 
     def _activation_and_log_det_3d(self, x):
@@ -156,7 +156,7 @@ class BlockAutoregressiveNetwork(AbstractBijection):
         x, log_abs_grads = eqx.filter_vmap(self.activation.transform_and_log_det)(x)
         log_det_3d = jnp.full((self.shape[0], self.block_dim, self.block_dim), -jnp.inf)
         log_det_3d = log_det_3d.at[
-            :, jnp.arange(self.block_dim), jnp.arange(self.block_dim)
+            :, jnp.arange(self.block_dim), jnp.arange(self.block_dim),
         ].set(log_abs_grads.reshape(self.shape[0], self.block_dim))
         return x, log_det_3d
 

--- a/flowjax/bijections/block_autoregressive_network.py
+++ b/flowjax/bijections/block_autoregressive_network.py
@@ -102,7 +102,10 @@ class BlockAutoregressiveNetwork(AbstractBijection):
             cond_dims = [cond_dim] + [None] * depth
 
             for layer_key, block_shape, cond_d in zip(
-                keys, block_shapes, cond_dims, strict=True,
+                keys,
+                block_shapes,
+                cond_dims,
+                strict=True,
             ):
                 layers.append(
                     BlockAutoregressiveLinear(layer_key, dim, block_shape, cond_d),
@@ -157,7 +160,9 @@ class BlockAutoregressiveNetwork(AbstractBijection):
         x, log_abs_grads = eqx.filter_vmap(self.activation.transform_and_log_det)(x)
         log_det_3d = jnp.full((self.shape[0], self.block_dim, self.block_dim), -jnp.inf)
         log_det_3d = log_det_3d.at[
-            :, jnp.arange(self.block_dim), jnp.arange(self.block_dim),
+            :,
+            jnp.arange(self.block_dim),
+            jnp.arange(self.block_dim),
         ].set(log_abs_grads.reshape(self.shape[0], self.block_dim))
         return x, log_det_3d
 

--- a/flowjax/bijections/block_autoregressive_network.py
+++ b/flowjax/bijections/block_autoregressive_network.py
@@ -12,7 +12,7 @@ from flowjax.bijections.tanh import LeakyTanh
 from flowjax.nn.block_autoregressive import BlockAutoregressiveLinear
 
 
-class _CallableToBijection(AbstractBijection, strict=True):
+class _CallableToBijection(AbstractBijection):
     """Wrap a callable e.g. a function or a callable module, into a bijection object
     (inverse not implemented). We assume the callable acts on scalar values
     and log_det can be computed in a stable manner with jax.grad.
@@ -41,7 +41,7 @@ class _CallableToBijection(AbstractBijection, strict=True):
         raise NotImplementedError()
 
 
-class BlockAutoregressiveNetwork(AbstractBijection, strict=True):
+class BlockAutoregressiveNetwork(AbstractBijection):
     r"""Block Autoregressive Network (https://arxiv.org/abs/1904.04676).Note that in
     contrast to the original paper which uses tanh activations, by default we use
     :py:class:`~flowjax.bijections.tanh.LeakyTanh`. This ensures the codomain of the

--- a/flowjax/bijections/block_autoregressive_network.py
+++ b/flowjax/bijections/block_autoregressive_network.py
@@ -13,10 +13,8 @@ from flowjax.nn.block_autoregressive import BlockAutoregressiveLinear
 
 
 class _CallableToBijection(AbstractBijection):
-    """Wrap a callable e.g. a function or a callable module, into a bijection object
-    (inverse not implemented). We assume the callable acts on scalar values
-    and log_det can be computed in a stable manner with jax.grad.
-    """
+    # Wrap a callable e.g. a function or a callable module. We assume the callable acts
+    # on scalar values and log_det can be computed in a stable manner with jax.grad.
 
     fn: Callable
     shape: ClassVar[tuple] = ()
@@ -42,9 +40,10 @@ class _CallableToBijection(AbstractBijection):
 
 
 class BlockAutoregressiveNetwork(AbstractBijection):
-    r"""Block Autoregressive Network (https://arxiv.org/abs/1904.04676).Note that in
-    contrast to the original paper which uses tanh activations, by default we use
-    :class:`~flowjax.bijections.tanh.LeakyTanh`. This ensures the codomain of the
+    r"""Block Autoregressive Network (https://arxiv.org/abs/1904.04676).
+
+    Note that in contrast to the original paper which uses tanh activations, by default
+    we use :class:`~flowjax.bijections.tanh.LeakyTanh`. This ensures the codomain of the
     activation is the set of real values, which will ensure properly normalised
     densities (see https://github.com/danielward27/flowjax/issues/102).
     """
@@ -64,7 +63,8 @@ class BlockAutoregressiveNetwork(AbstractBijection):
         block_dim: int,
         activation: AbstractBijection | Callable | None = None,
     ):
-        """
+        """Initialize the bijection.
+
         Args:
             key (KeyArray): Jax PRNGKey
             dim (int): Dimension of the distribution.
@@ -152,8 +152,7 @@ class BlockAutoregressiveNetwork(AbstractBijection):
         )
 
     def _activation_and_log_det_3d(self, x):
-        """Compute the activation and the log determinant with shape
-        (num_blocks, block_dim, block_dim)"""
+        """Compute activation and the log determinant (blocks, block_dim, block_dim)."""
         x, log_abs_grads = eqx.filter_vmap(self.activation.transform_and_log_det)(x)
         log_det_3d = jnp.full((self.shape[0], self.block_dim, self.block_dim), -jnp.inf)
         log_det_3d = log_det_3d.at[
@@ -163,10 +162,10 @@ class BlockAutoregressiveNetwork(AbstractBijection):
 
 
 def logmatmulexp(x, y):
-    """
-    Numerically stable version of ``(x.log() @ y.log()).exp()``.
+    """Numerically stable version of ``(x.log() @ y.log()).exp()``.
+
     From numpyro https://github.com/pyro-ppl/numpyro/blob/
-    f2ff89a3a7147617e185eb51148eb15d56d44661/numpyro/distributions/util.py#L387
+    f2ff89a3a7147617e185eb51148eb15d56d44661/numpyro/distributions/util.py#L387.
     """
     x_shift = jax.lax.stop_gradient(jnp.amax(x, -1, keepdims=True))
     y_shift = jax.lax.stop_gradient(jnp.amax(y, -2, keepdims=True))

--- a/flowjax/bijections/block_autoregressive_network.py
+++ b/flowjax/bijections/block_autoregressive_network.py
@@ -1,5 +1,6 @@
 """Block Neural Autoregressive bijection implementation."""
-from typing import Callable, ClassVar
+from collections.abc import Callable
+from typing import ClassVar
 
 import equinox as eqx
 import jax
@@ -21,8 +22,8 @@ class _CallableToBijection(AbstractBijection):
     cond_shape: ClassVar[None] = None
 
     def __init__(self, fn: Callable):
-        if not isinstance(fn, Callable):
-            raise ValueError(f"Expected callable, got {type(fn)}.")
+        if not callable(fn):
+            raise TypeError(f"Expected callable, got {type(fn)}.")
         self.fn = fn
 
     def transform(self, x, condition=None):
@@ -33,10 +34,10 @@ class _CallableToBijection(AbstractBijection):
         return y, jnp.log(jnp.abs(grad))
 
     def inverse(self, y, condition=None):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def inverse_and_log_det(self, y, condition=None):
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class BlockAutoregressiveNetwork(AbstractBijection):

--- a/flowjax/bijections/block_autoregressive_network.py
+++ b/flowjax/bijections/block_autoregressive_network.py
@@ -120,7 +120,7 @@ class BlockAutoregressiveNetwork(AbstractBijection):
             x = layer(x, condition)[0]
             x = eqx.filter_vmap(self.activation.transform)(x)
             condition = None
-        return self.layers[-1](x)[0]
+        return self.layers[-1](x, condition)[0]
 
     def transform_and_log_det(self, x, condition=None):
         x, condition = self._argcheck_and_cast(x, condition)
@@ -133,7 +133,7 @@ class BlockAutoregressiveNetwork(AbstractBijection):
             log_jacobian_3ds.append(log_det_3d)
             condition = None  # only pass array condition to first layer
 
-        x, log_det_3d = self.layers[-1](x)
+        x, log_det_3d = self.layers[-1](x, condition)
         log_jacobian_3ds.append(log_det_3d)
 
         log_det = log_jacobian_3ds[-1]

--- a/flowjax/bijections/chain.py
+++ b/flowjax/bijections/chain.py
@@ -3,16 +3,18 @@ arbitrary bijections, with compatible shapes.
 """
 from typing import Sequence
 
-from flowjax.bijections.bijection import Bijection
+from flowjax.bijections.bijection import AbstractBijection
 from flowjax.utils import check_shapes_match, merge_cond_shapes
 
 
-class Chain(Bijection):
+class Chain(AbstractBijection, strict=True):
     """Chain together arbitrary bijections to form another bijection."""
 
-    bijections: tuple[Bijection]
+    shape: tuple[int, ...]
+    cond_shape: tuple[int, ...] | None
+    bijections: tuple[AbstractBijection]
 
-    def __init__(self, bijections: Sequence[Bijection]):
+    def __init__(self, bijections: Sequence[AbstractBijection]):
         """
         Args:
             bijections (Sequence[Bijection]): Sequence of bijections.
@@ -46,7 +48,7 @@ class Chain(Bijection):
             log_abs_det_jac += log_abs_det_jac_i.sum()
         return y, log_abs_det_jac
 
-    def __getitem__(self, i: int | slice) -> Bijection:
+    def __getitem__(self, i: int | slice) -> AbstractBijection:
         if isinstance(i, int):
             return self.bijections[i]
         if isinstance(i, slice):

--- a/flowjax/bijections/chain.py
+++ b/flowjax/bijections/chain.py
@@ -1,5 +1,5 @@
 """Chain bijection which allows sequential application of arbitrary bijections."""
-from typing import Sequence
+from collections.abc import Sequence
 
 from flowjax.bijections.bijection import AbstractBijection
 from flowjax.utils import check_shapes_match, merge_cond_shapes

--- a/flowjax/bijections/chain.py
+++ b/flowjax/bijections/chain.py
@@ -1,6 +1,4 @@
-"""Module contains the Chain bijection, that allows sequentially application of
-arbitrary bijections, with compatible shapes.
-"""
+"""Chain bijection which allows sequential application of arbitrary bijections."""
 from typing import Sequence
 
 from flowjax.bijections.bijection import AbstractBijection
@@ -15,9 +13,12 @@ class Chain(AbstractBijection):
     bijections: tuple[AbstractBijection]
 
     def __init__(self, bijections: Sequence[AbstractBijection]):
-        """
+        """Initialize the chain bijection.
+
         Args:
-            bijections (Sequence[Bijection]): Sequence of bijections.
+            bijections (Sequence[Bijection]): Sequence of bijections. The bijection
+            shapes must match, and any none None condition shapes must match.
+
         """
         check_shapes_match([b.shape for b in bijections])
         self.shape = bijections[0].shape
@@ -62,8 +63,7 @@ class Chain(AbstractBijection):
         return len(self.bijections)
 
     def merge_chains(self):
-        """Returns an equivilent Chain object, in which nested chains are flattened into
-        a sigle chain."""
+        """Returns an equivilent Chain object, in which nested chains are flattened."""
         bijections = self.bijections
         while any(isinstance(b, Chain) for b in bijections):
             bij = []

--- a/flowjax/bijections/chain.py
+++ b/flowjax/bijections/chain.py
@@ -7,7 +7,7 @@ from flowjax.bijections.bijection import AbstractBijection
 from flowjax.utils import check_shapes_match, merge_cond_shapes
 
 
-class Chain(AbstractBijection, strict=True):
+class Chain(AbstractBijection):
     """Chain together arbitrary bijections to form another bijection."""
 
     shape: tuple[int, ...]

--- a/flowjax/bijections/concatenate.py
+++ b/flowjax/bijections/concatenate.py
@@ -84,7 +84,7 @@ class Concatenate(AbstractBijection):
         return jnp.concatenate(x_parts, self.axis), sum(log_dets)
 
     def _argcheck_shapes(self, shapes: Sequence[tuple[int, ...]]):
-        axis = range(len(shapes[0]))[self.axis]   # Avoid negative index
+        axis = range(len(shapes[0]))[self.axis]  # Avoid negative index
         expected_matching = shapes[0][:axis] + shapes[0][axis + 1 :]
         for i, shape in enumerate(shapes):
             if shape[:axis] + shape[axis + 1 :] != expected_matching:

--- a/flowjax/bijections/concatenate.py
+++ b/flowjax/bijections/concatenate.py
@@ -10,8 +10,9 @@ from flowjax.utils import check_shapes_match, merge_cond_shapes
 
 
 class Concatenate(AbstractBijection):
-    """Concatenate bijections along an already existing axis. Analagous to
-    ``jnp.concatenate``. See also :class:`Stack`.
+    """Concatenate bijections along an existing axis, similar to ``jnp.concatenate``.
+
+    See also :class:`Stack`.
     """
 
     shape: tuple[int, ...]
@@ -21,7 +22,8 @@ class Concatenate(AbstractBijection):
     axis: int
 
     def __init__(self, bijections: Sequence[AbstractBijection], axis: int = 0):
-        """
+        """Initialize the bijection.
+
         Args:
             bijections (Sequence[Bijection]): Bijections, to stack into a single
                 bijection.
@@ -93,8 +95,8 @@ class Concatenate(AbstractBijection):
 
 
 class Stack(AbstractBijection):
-    """
-    Stack bijections along a new axis (analagous to ``jnp.stack``).
+    """Stack bijections along a new axis (analagous to ``jnp.stack``).
+
     See also :class:`Concatenate`.
     """
 
@@ -104,7 +106,8 @@ class Stack(AbstractBijection):
     axis: int
 
     def __init__(self, bijections: list[AbstractBijection], axis: int = 0):
-        """
+        """Initialize the bijection.
+
         Args:
             bijections (list[Bijection]): Bijections.
             axis (int): Axis along which to stack. Defaults to 0.

--- a/flowjax/bijections/concatenate.py
+++ b/flowjax/bijections/concatenate.py
@@ -5,20 +5,22 @@ from typing import Sequence
 import jax.numpy as jnp
 from jax import Array
 
-from flowjax.bijections.bijection import Bijection
+from flowjax.bijections.bijection import AbstractBijection
 from flowjax.utils import check_shapes_match, merge_cond_shapes
 
 
-class Concatenate(Bijection):
+class Concatenate(AbstractBijection, strict=True):
     """Concatenate bijections along an already existing axis. Analagous to
     ``jnp.concatenate``. See also :class:`Stack`.
     """
 
+    shape: tuple[int, ...]
+    cond_shape: tuple[int, ...] | None
     split_idxs: Array
-    bijections: Sequence[Bijection]
+    bijections: Sequence[AbstractBijection]
     axis: int
 
-    def __init__(self, bijections: Sequence[Bijection], axis: int = 0):
+    def __init__(self, bijections: Sequence[AbstractBijection], axis: int = 0):
         """
         Args:
             bijections (Sequence[Bijection]): Bijections, to stack into a single
@@ -90,16 +92,18 @@ class Concatenate(Bijection):
                 )
 
 
-class Stack(Bijection):
+class Stack(AbstractBijection, strict=True):
     """
     Stack bijections along a new axis (analagous to ``jnp.stack``).
     See also :class:`Concatenate`.
     """
 
-    bijections: Sequence[Bijection]
+    shape: tuple[int, ...]
+    cond_shape: tuple[int, ...] | None
+    bijections: Sequence[AbstractBijection]
     axis: int
 
-    def __init__(self, bijections: list[Bijection], axis: int = 0):
+    def __init__(self, bijections: list[AbstractBijection], axis: int = 0):
         """
         Args:
             bijections (list[Bijection]): Bijections.

--- a/flowjax/bijections/concatenate.py
+++ b/flowjax/bijections/concatenate.py
@@ -9,7 +9,7 @@ from flowjax.bijections.bijection import AbstractBijection
 from flowjax.utils import check_shapes_match, merge_cond_shapes
 
 
-class Concatenate(AbstractBijection, strict=True):
+class Concatenate(AbstractBijection):
     """Concatenate bijections along an already existing axis. Analagous to
     ``jnp.concatenate``. See also :class:`Stack`.
     """
@@ -92,7 +92,7 @@ class Concatenate(AbstractBijection, strict=True):
                 )
 
 
-class Stack(AbstractBijection, strict=True):
+class Stack(AbstractBijection):
     """
     Stack bijections along a new axis (analagous to ``jnp.stack``).
     See also :class:`Concatenate`.

--- a/flowjax/bijections/concatenate.py
+++ b/flowjax/bijections/concatenate.py
@@ -90,7 +90,7 @@ class Concatenate(AbstractBijection):
             if shp[:axis] + shp[axis + 1 :] != shapes[0][:axis] + shapes[0][axis + 1 :]:
                 raise ValueError(
                     f"Expected bijection shapes to match except along axis {axis}, but "
-                    f"index 0 had shape {shapes[0]}, and index {i} had shape {shp}."
+                    f"index 0 had shape {shapes[0]}, and index {i} had shape {shp}.",
                 )
 
 

--- a/flowjax/bijections/coupling.py
+++ b/flowjax/bijections/coupling.py
@@ -1,5 +1,6 @@
 """Implemenetation of Coupling flow layer with arbitrary transformer.
-See https://arxiv.org/abs/1605.08803 for more information.
+
+Ref: https://arxiv.org/abs/1605.08803.
 """
 from typing import Callable
 
@@ -34,13 +35,14 @@ class Coupling(AbstractBijection):
         nn_depth: int,
         nn_activation: Callable = jnn.relu,
     ):
-        """
+        """Initialize the coupling bijection.
+
         Args:
             key (KeyArray): Jax PRNGKey
-            transformer (AbstractBijection): Unconditional bijection with shape () to be
-                parameterised by the conditioner neural netork.
-            untransformed_dim (int): Number of untransformed conditioning variables (
-                e.g. dim // 2).
+            transformer (AbstractBijection): Unconditional bijection with shape ()
+                to be parameterised by the conditioner neural netork.
+            untransformed_dim (int): Number of untransformed conditioning variables
+                (e.g. dim // 2).
             dim (int): Total dimension.
             cond_dim (int | None): Dimension of additional conditioning variables.
             nn_width (int): Neural network hidden layer width.

--- a/flowjax/bijections/coupling.py
+++ b/flowjax/bijections/coupling.py
@@ -52,11 +52,11 @@ class Coupling(AbstractBijection):
         """
         if transformer.shape != () or transformer.cond_shape is not None:
             raise ValueError(
-                "Only unconditional transformers with shape () are supported."
+                "Only unconditional transformers with shape () are supported.",
             )
 
         constructor, transformer_init_params = get_ravelled_bijection_constructor(
-            transformer
+            transformer,
         )
 
         self.transformer_constructor = constructor

--- a/flowjax/bijections/coupling.py
+++ b/flowjax/bijections/coupling.py
@@ -9,11 +9,11 @@ import jax.numpy as jnp
 from jax.random import KeyArray
 
 from flowjax.bijections.bijection import AbstractBijection
-from flowjax.bijections.jax_transforms import Batch
+from flowjax.bijections.jax_transforms import Vmap
 from flowjax.utils import Array, get_ravelled_bijection_constructor
 
 
-class Coupling(AbstractBijection, strict=True):
+class Coupling(AbstractBijection):
     """Coupling layer implementation (https://arxiv.org/abs/1605.08803)."""
 
     shape: tuple[int, ...]
@@ -126,4 +126,4 @@ class Coupling(AbstractBijection, strict=True):
         dim = self.dim - self.untransformed_dim
         transformer_params = jnp.reshape(params, (dim, -1))
         transformer = eqx.filter_vmap(self.transformer_constructor)(transformer_params)
-        return Batch(transformer, (dim,), vectorize_bijection=True)
+        return Vmap(transformer, in_axis=eqx.if_array(0))

--- a/flowjax/bijections/coupling.py
+++ b/flowjax/bijections/coupling.py
@@ -2,7 +2,7 @@
 
 Ref: https://arxiv.org/abs/1605.08803.
 """
-from typing import Callable
+from collections.abc import Callable
 
 import equinox as eqx
 import jax.nn as jnn
@@ -78,11 +78,11 @@ class Coupling(AbstractBijection):
             depth=nn_depth,
             activation=nn_activation,
             key=key,
-        )  # type: eqx.nn.MLP
+        )
 
         # Initialise last bias terms to match the provided transformer parameters
         self.conditioner = eqx.tree_at(
-            where=lambda mlp: mlp.layers[-1].bias,  # type: ignore
+            where=lambda mlp: mlp.layers[-1].bias,
             pytree=conditioner,
             replace=jnp.tile(transformer_init_params, dim - untransformed_dim),
         )
@@ -93,8 +93,7 @@ class Coupling(AbstractBijection):
         transformer_params = self.conditioner(nn_input)
         transformer = self._flat_params_to_transformer(transformer_params)
         y_trans = transformer.transform(x_trans)
-        y = jnp.hstack((x_cond, y_trans))
-        return y
+        return jnp.hstack((x_cond, y_trans))
 
     def transform_and_log_det(self, x, condition=None):
         x_cond, x_trans = x[: self.untransformed_dim], x[self.untransformed_dim :]
@@ -111,8 +110,7 @@ class Coupling(AbstractBijection):
         transformer_params = self.conditioner(nn_input)
         transformer = self._flat_params_to_transformer(transformer_params)
         x_trans = transformer.inverse(y_trans)
-        x = jnp.hstack((x_cond, x_trans))
-        return x
+        return jnp.hstack((x_cond, x_trans))
 
     def inverse_and_log_det(self, y, condition=None):
         x_cond, y_trans = y[: self.untransformed_dim], y[self.untransformed_dim :]

--- a/flowjax/bijections/coupling.py
+++ b/flowjax/bijections/coupling.py
@@ -8,14 +8,16 @@ import jax.nn as jnn
 import jax.numpy as jnp
 from jax.random import KeyArray
 
-from flowjax.bijections.bijection import Bijection
+from flowjax.bijections.bijection import AbstractBijection
 from flowjax.bijections.jax_transforms import Batch
 from flowjax.utils import Array, get_ravelled_bijection_constructor
 
 
-class Coupling(Bijection):
+class Coupling(AbstractBijection, strict=True):
     """Coupling layer implementation (https://arxiv.org/abs/1605.08803)."""
 
+    shape: tuple[int, ...]
+    cond_shape: tuple[int, ...] | None
     untransformed_dim: int
     dim: int
     transformer_constructor: Callable
@@ -24,7 +26,7 @@ class Coupling(Bijection):
     def __init__(
         self,
         key: KeyArray,
-        transformer: Bijection,
+        transformer: AbstractBijection,
         untransformed_dim: int,
         dim: int,
         cond_dim: int | None,

--- a/flowjax/bijections/coupling.py
+++ b/flowjax/bijections/coupling.py
@@ -37,7 +37,7 @@ class Coupling(AbstractBijection):
         """
         Args:
             key (KeyArray): Jax PRNGKey
-            transformer (Bijection): Unconditional bijection with shape () to be
+            transformer (AbstractBijection): Unconditional bijection with shape () to be
                 parameterised by the conditioner neural netork.
             untransformed_dim (int): Number of untransformed conditioning variables (
                 e.g. dim // 2).

--- a/flowjax/bijections/exp.py
+++ b/flowjax/bijections/exp.py
@@ -1,4 +1,4 @@
-"""Exponential bijection"""
+"""Exponential bijection."""
 from typing import ClassVar
 
 import jax.numpy as jnp

--- a/flowjax/bijections/exp.py
+++ b/flowjax/bijections/exp.py
@@ -8,6 +8,7 @@ from flowjax.bijections.bijection import AbstractBijection
 
 class Exp(AbstractBijection):
     """Elementwise exponential transform (forward) and log transform (inverse).
+
     Args:
         shape (tuple[int, ...] | None): Shape of the bijection.
             Defaults to None.

--- a/flowjax/bijections/exp.py
+++ b/flowjax/bijections/exp.py
@@ -1,20 +1,20 @@
 """Exponential bijection"""
+from typing import ClassVar
+
 import jax.numpy as jnp
 
-from flowjax.bijections.bijection import Bijection
+from flowjax.bijections.bijection import AbstractBijection
 
 
-class Exp(Bijection):
-    """Elementwise exponential transform (forward) and log transform (inverse)."""
+class Exp(AbstractBijection):
+    """Elementwise exponential transform (forward) and log transform (inverse).
+    Args:
+        shape (tuple[int, ...] | None): Shape of the bijection.
+            Defaults to None.
+    """
 
-    def __init__(self, shape: tuple[int, ...] = ()):
-        """
-        Args:
-            shape (tuple[int, ...] | None): Shape of the bijection.
-                Defaults to None.
-        """
-        self.shape = shape
-        self.cond_shape = None
+    shape: tuple[int, ...] = ()
+    cond_shape: ClassVar[None] = None
 
     def transform(self, x, condition=None):
         x, _ = self._argcheck_and_cast(x)

--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -1,6 +1,6 @@
 """Bijections that wrap jax function transforms (scan and vmap)."""
 
-from typing import Callable
+from collections.abc import Callable
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -190,7 +190,7 @@ class Vmap(AbstractBijection):
 
     @property
     def shape(self):
-        return (self.axis_size,) + self.bijection.shape
+        return (self.axis_size, *self.bijection.shape)
 
     @property
     def cond_shape(self):
@@ -268,9 +268,8 @@ def _resolve_vmapped_axes(pytree, in_axes):
     def _resolve_axis(in_axes, elem):
         if in_axes is None or isinstance(in_axes, int):
             return tree_map(lambda _: in_axes, elem)
-        elif callable(in_axes):
+        if callable(in_axes):
             return tree_map(in_axes, elem)
-        else:
-            raise ValueError("`in_axes` must consist of None, ints, and callables.")
+        raise TypeError("`in_axes` must consist of None, ints, and callables.")
 
     return tree_map(_resolve_axis, in_axes, pytree, is_leaf=lambda x: x is None)

--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -25,7 +25,7 @@ class Scan(AbstractBijection):
         over. Often it is convenient to construct these using ``equinox.filter_vmap``.
 
         Args:
-            bijection (Bijection): A bijection, in which the arrays leaves have an
+            bijection (AbstractBijection): A bijection, in which the arrays leaves have an
                 additional leading axis to scan over. For complex bijections, it can be
                 convenient to create compatible bijections with ``equinox.filter_vmap``.
 

--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -1,144 +1,23 @@
 """Bijections that wrap jax function transforms (scan and vmap)."""
-from functools import partial
-from typing import Any, Callable
+
+from typing import Callable
 
 import equinox as eqx
 import jax.numpy as jnp
-from equinox import AbstractVar
 from jax.lax import scan
+from jax.tree_util import tree_leaves, tree_map
 
 from flowjax.bijections.bijection import AbstractBijection
 
 
-class AbstractBatch(
-    AbstractBijection, strict=True
-):  # TODO this might needs rethinking - also potentially renaming due to the possbility of Batched distributions?
-    """Abstract class to facilitate adding batch dimensions to a bijection.
-    Add batch dimensions to a bijection, such that the new shape is
-    batch_shape + bijection.shape. The batch dimensions are added using multiple
-    applications of eqx.filter_vmap.
-    """
-
-    shape: AbstractVar[tuple[int, ...]]
-    cond_shape: AbstractVar[tuple[int, ...] | None]
-    bijection: AbstractVar[AbstractBijection]
-    in_axes: AbstractVar[tuple]
-    batch_shape: AbstractVar[tuple[int, ...]]
-
-    def transform(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
-
-        def _transform(bijection, x, condition):
-            return bijection.transform(x, condition)
-
-        return self.multi_vmap(_transform)(self.bijection, x, condition)
-
-    def transform_and_log_det(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
-
-        def _transform_and_log_det(bijection, x, condition):
-            return bijection.transform_and_log_det(x, condition)
-
-        y, log_det = self.multi_vmap(_transform_and_log_det)(
-            self.bijection, x, condition
-        )
-        return y, jnp.sum(log_det)
-
-    def inverse(self, y, condition=None):
-        y, condition = self._argcheck_and_cast(y, condition)
-
-        def _inverse(bijection, x, condition):
-            return bijection.inverse(x, condition)
-
-        return self.multi_vmap(_inverse)(self.bijection, y, condition)
-
-    def inverse_and_log_det(self, y, condition=None):
-        y, condition = self._argcheck_and_cast(y, condition)
-
-        def _inverse_and_log_det(bijection, x, condition):
-            return bijection.inverse_and_log_det(x, condition)
-
-        x, log_det = self.multi_vmap(_inverse_and_log_det)(self.bijection, y, condition)
-        return x, jnp.sum(log_det)
-
-    def multi_vmap(self, func: Callable) -> Callable:
-        """Compose vmap to add ndim batch dimensions."""
-        for _ in range(len(self.batch_shape)):
-            func = eqx.filter_vmap(func, in_axes=self.in_axes)
-        return func
-
-
-class Batch(AbstractBatch, strict=True):
-    shape: tuple[int, ...]
-    cond_shape: tuple[int, ...] | None
-    bijection: AbstractBijection
-    in_axes: tuple
-    batch_shape: tuple[int, ...]
-
-    def __init__(
-        self,
-        bijection: AbstractBijection,
-        batch_shape: tuple[int, ...],
-        vectorize_bijection: bool,
-        vectorize_condition: bool | None = None,
-    ):
-        """
-        Args:
-            bijection (Bijection): Bijection to add batch dimensions to.
-            batch_shape (tuple[int, ...]): The shape of the batch dimension.
-            vectorize_bijection (bool): Whether to vectorise bijection parameters.
-                If True, we vectorize across the leading dimensions in the array
-                leaves of the bijection. In this case, the array leaves must
-                have leading dimensions equal to batch_shape. For construction of
-                compatible bijections, see ``eqx.filter_vmap``. If False: we broadcast
-                the parameters, i.e. the same bijection parameters are used for each x.
-            vectorize_condition (bool | None): Whether to vectorize or broadcast the
-                conditioning variables. If broadcasting, the condition shape is
-                unchanged. If vectorising, the condition shape will be
-                ``batch_shape + bijection.cond_shape``. Defaults to None.
-
-        Example:
-
-            .. doctest::
-
-                >>> import jax.numpy as jnp
-                >>> from flowjax.bijections import Batch, Affine
-                >>> x = jnp.ones(2)
-                >>> batched = Batch(Affine(1), (2,), vectorize_bijection=False)
-                >>> batched.transform(x)
-                Array([2., 2.], dtype=float32)
-        """
-        if vectorize_condition is None and bijection.cond_shape is not None:
-            raise ValueError(
-                "vectorize_condition must be specified for conditional bijections."
-            )
-
-        self.in_axes = (
-            eqx.if_array(axis=0) if vectorize_bijection else None,
-            eqx.if_array(axis=0),
-            0 if vectorize_condition else None,
-        )
-        self.shape = batch_shape + bijection.shape
-        self.batch_shape = batch_shape
-        self.bijection = bijection
-
-        if self.bijection.cond_shape is None:
-            self.cond_shape = None
-        elif vectorize_condition:
-            self.cond_shape = batch_shape + self.bijection.cond_shape
-        else:
-            self.cond_shape = self.bijection.cond_shape
-
-
-class Scan(AbstractBijection, strict=True):
+class Scan(AbstractBijection):
     """Repeatedly apply the same bijection with different parameter values. Internally,
     uses `jax.lax.scan` to reduce compilation time.
     """
 
     shape: tuple[int, ...]
     cond_shape: tuple[int, ...] | None
-    static: Any
-    params: Any
+    bijection: AbstractBijection
 
     def __init__(self, bijection: AbstractBijection):
         """
@@ -159,59 +38,233 @@ class Scan(AbstractBijection, strict=True):
                 >>> import jax.numpy as jnp
                 >>> import equinox as eqx
                 >>> params = jnp.ones((3, 2))
-                >>> affine = Scan(Affine(params))
-
+                >>> affine = eqx.filter_vmap(Affine)(params)
+                >>> affine = Scan(affine)
         """
-        self.params, self.static = eqx.partition(bijection, eqx.is_array)
         self.shape = bijection.shape
         self.cond_shape = bijection.cond_shape
+        self.bijection = bijection
 
     def transform(self, x, condition=None):
         x, condition = self._argcheck_and_cast(x, condition)
 
-        def step(x, params, condition=None):
-            bijection = eqx.combine(self.static, params)
-            result = bijection.transform(x, condition)
-            return (result, None)
+        def step(x, bijection):
+            return (bijection.transform(x, condition), None)
 
-        step = partial(step, condition=condition)
-        y, _ = scan(step, x, self.params)
+        y, _ = _filter_scan(step, x, self.bijection)
         return y
 
     def transform_and_log_det(self, x, condition=None):
         x, condition = self._argcheck_and_cast(x, condition)
 
-        def step(carry, params, condition):
+        def step(carry, bijection):
             x, log_det = carry
-            bijection = eqx.combine(self.static, params)
-            y, log_det_i = bijection.transform_and_log_det(x, condition)  # type: ignore
+            y, log_det_i = bijection.transform_and_log_det(x, condition)
             return ((y, log_det + log_det_i.sum()), None)
 
-        step = partial(step, condition=condition)
-        (y, log_det), _ = scan(step, (x, 0), self.params)
+        (y, log_det), _ = _filter_scan(step, (x, 0), self.bijection)
         return y, log_det
 
     def inverse(self, y, condition=None):
         y, _ = self._argcheck_and_cast(y, condition)
 
-        def step(y, params, condition):
-            bijection = eqx.combine(self.static, params)
-            x = bijection.inverse(y, condition)  # type: ignore
-            return (x, None)
+        def step(y, bijection):
+            return bijection.inverse(y, condition), None
 
-        step = partial(step, condition=condition)
-        x, _ = scan(step, y, self.params, reverse=True)
+        x, _ = _filter_scan(step, y, self.bijection, reverse=True)
         return x
 
     def inverse_and_log_det(self, y, condition=None):
         y, _ = self._argcheck_and_cast(y, condition)
 
-        def step(carry, params, condition):
+        def step(carry, bijection):
             y, log_det = carry
-            bijection = eqx.combine(self.static, params)
-            x, log_det_i = bijection.inverse_and_log_det(y, condition)  # type: ignore
+            x, log_det_i = bijection.inverse_and_log_det(y, condition)
             return ((x, log_det + log_det_i.sum()), None)
 
-        step = partial(step, condition=condition)
-        (y, log_det), _ = scan(step, (y, 0), self.params, reverse=True)
+        (y, log_det), _ = _filter_scan(step, (y, 0), self.bijection, reverse=True)
         return y, log_det
+
+
+def _filter_scan(f, init, xs, reverse=False):
+    params, static = eqx.partition(xs, filter_spec=eqx.is_array)
+
+    def _scan_fn(carry, x):
+        module = eqx.combine(x, static)
+        carry, y = f(carry, module)
+        return carry, y
+
+    return scan(_scan_fn, init, params, reverse=reverse)
+
+
+class Vmap(AbstractBijection):
+    """Applies vmap to bijection methods to add a batch dimension to the bijection.
+
+    Example:
+
+        The two most common use cases, are shown below:
+
+        .. doctest::
+
+            Add a batch dimension to a bijection, mapping over bijection parameters:
+
+            >>> import jax.numpy as jnp
+            >>> import equinox as eqx
+            >>> from flowjax.bijections import Vmap, RationalQuadraticSpline
+            >>> bijection = eqx.filter_vmap(RationalQuadraticSpline, axis_size=10)(5, 2)
+            >>> bijection = Vmap(bijection, eqx.if_array(0))
+            >>> bijection.shape
+            (10,)
+
+            Add a batch dimension to a bijection, broadcasting bijection parameters:
+            >>> bijection = RationalQuadraticSpline(5, 2)
+            >>> bijection = Vmap(bijection, axis_size=10)
+            >>> bijection.shape
+            (10,)
+
+        A more advanced use case is to create bijections with more fine grained control
+        over parameter broadcasting. For example, ``Affine`` broadcasts the location and
+        scale parameters. What if we want an ``Affine`` bijection, with a global scale
+        parameter, but an elementwise location parameter? We could achieve this as
+        follows
+
+            >>> bijection = Affine(jnp.zeros(()), jnp.ones(()))
+            >>> bijection = eqx.tree_at(lambda bij: bij.loc, bijection, jnp.arange(3))
+            >>> in_axis = tree_map(lambda _: None, bijection)
+            >>> in_axis = eqx.tree_at(lambda bij: bij.loc, in_axis, 0, is_leaf=lambda x: x is None)
+            >>> bijection = Vmap(bijection, in_axis=in_axis)
+            >>> bijection.shape
+            (3,)
+            >>> bijection.bijection.loc.shape
+            (3,)
+            >>> bijection.bijection.scale.shape
+            ()
+
+            >>> x = jnp.ones(3)
+            >>> bijection.transform(x)
+            Array([1., 2., 3.], dtype=float32)
+
+    """
+
+    bijection: AbstractBijection
+    in_axes: tuple
+    axis_size: int
+
+    def __init__(
+        self,
+        bijection: AbstractBijection,
+        in_axis: int | None | Callable = None,
+        axis_size: int | None = None,
+        in_axis_condition: int | None = None,
+    ):
+        """
+        Args:
+            bijection (AbstractBijection): The bijection to vectorize.
+            in_axis (int | None | Callable): Specify which axes of the bijection
+                parameters to vectorise over. It should be a PyTree of ``None``, ``int``
+                with the tree structure being a prefix of the bijection, or a callable
+                mapping ``Leaf -> Union[None, int]``. Defaults to None.
+            axis_size (int, optional): The size of the new axis. This should be left
+                unspecified if in_axis is provided, as the size can be inferred from the
+                bijection parameters. Defaults to None.
+            in_axis_condition (int | None, optional): Optionally define an axis of
+                the conditioning variable to vectorize over. Defaults to None.
+        """
+        if in_axis is not None and axis_size is not None:
+            raise ValueError("Cannot specify both in_axis and axis_size.")
+
+        if axis_size is None:
+            if in_axis is None:
+                raise ValueError("Either axis_size or in_axis must be provided.")
+            axis_size = _infer_axis_size_from_params(bijection, in_axis)
+
+        self.in_axes = (in_axis, 0, in_axis_condition)
+        self.bijection = bijection
+        self.axis_size = axis_size
+
+    @property
+    def shape(self):
+        return (self.axis_size,) + self.bijection.shape
+
+    @property
+    def cond_shape(self):
+        ax = self.in_axes[2]
+        if self.bijection.cond_shape is None or ax is None:
+            return self.bijection.cond_shape
+
+        return (
+            *self.bijection.cond_shape[:ax],
+            self.axis_size,
+            *self.bijection.cond_shape[ax:],
+        )
+
+    def transform(self, x, condition=None):
+        x, condition = self._argcheck_and_cast(x, condition)
+
+        def _transform(bijection, x, condition):
+            return bijection.transform(x, condition)
+
+        return eqx.filter_vmap(_transform, in_axes=self.in_axes)(
+            self.bijection, x, condition
+        )
+
+    def transform_and_log_det(self, x, condition=None):
+        x, condition = self._argcheck_and_cast(x, condition)
+
+        def _transform_and_log_det(bijection, x, condition):
+            return bijection.transform_and_log_det(x, condition)
+
+        y, log_det = eqx.filter_vmap(_transform_and_log_det, in_axes=self.in_axes)(
+            self.bijection, x, condition
+        )
+        return y, jnp.sum(log_det)
+
+    def inverse(self, y, condition=None):
+        y, condition = self._argcheck_and_cast(y, condition)
+
+        def _inverse(bijection, x, condition):
+            return bijection.inverse(x, condition)
+
+        return eqx.filter_vmap(_inverse, in_axes=self.in_axes)(
+            self.bijection, y, condition
+        )
+
+    def inverse_and_log_det(self, y, condition=None):
+        y, condition = self._argcheck_and_cast(y, condition)
+
+        def _inverse_and_log_det(bijection, x, condition):
+            return bijection.inverse_and_log_det(x, condition)
+
+        x, log_det = eqx.filter_vmap(_inverse_and_log_det, in_axes=self.in_axes)(
+            self.bijection, y, condition
+        )
+        return x, jnp.sum(log_det)
+
+
+def _infer_axis_size_from_params(tree, in_axis):
+    axes = _resolve_vmapped_axes(tree, in_axis)
+    axis_sizes = tree_leaves(
+        tree_map(
+            lambda leaf, ax: leaf.shape[ax] if ax is not None else None,
+            tree,
+            axes,
+        )
+    )
+    if len(axis_sizes) == 0:
+        raise ValueError("in_axis did not map to any leaves to vectorize.")
+    return axis_sizes[0]
+
+
+def _resolve_vmapped_axes(pytree, in_axes):
+    "Returns pytree with ints denoting vmapped dimensions."
+
+    # Adapted from equinox filter_vmap
+    def _resolve_axis(in_axes, elem):
+        if in_axes is None or isinstance(in_axes, int):
+            return tree_map(lambda _: in_axes, elem)
+        elif callable(in_axes):
+            return tree_map(in_axes, elem)
+        else:
+            raise ValueError("`in_axes` must consist of None, ints, and callables.")
+
+    return tree_map(_resolve_axis, in_axes, pytree, is_leaf=lambda x: x is None)

--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -11,8 +11,9 @@ from flowjax.bijections.bijection import AbstractBijection
 
 
 class Scan(AbstractBijection):
-    """Repeatedly apply the same bijection with different parameter values. Internally,
-    uses `jax.lax.scan` to reduce compilation time.
+    """Repeatedly apply the same bijection with different parameter values.
+
+    Internally, uses `jax.lax.scan` to reduce compilation time.
     """
 
     shape: tuple[int, ...]
@@ -20,14 +21,16 @@ class Scan(AbstractBijection):
     bijection: AbstractBijection
 
     def __init__(self, bijection: AbstractBijection):
-        """
+        """Initialize the scan bijection.
+
         The array leaves in `bijection` should have an additional leading axis to scan
         over. Often it is convenient to construct these using ``equinox.filter_vmap``.
 
         Args:
-            bijection (AbstractBijection): A bijection, in which the arrays leaves have an
-                additional leading axis to scan over. For complex bijections, it can be
-                convenient to create compatible bijections with ``equinox.filter_vmap``.
+            bijection (AbstractBijection): A bijection, in which the arrays leaves have
+                an additional leading axis to scan over. For complex bijections, it can
+                be convenient to create compatible bijections with
+                ``equinox.filter_vmap``.
 
         Example:
             Below is equivilent to ``Chain([Affine(p) for p in params])``.
@@ -101,7 +104,6 @@ class Vmap(AbstractBijection):
     """Applies vmap to bijection methods to add a batch dimension to the bijection.
 
     Example:
-
         The two most common use cases, are shown below:
 
         .. doctest::
@@ -160,7 +162,8 @@ class Vmap(AbstractBijection):
         axis_size: int | None = None,
         in_axis_condition: int | None = None,
     ):
-        """
+        """Initialize the bijection.
+
         Args:
             bijection (AbstractBijection): The bijection to vectorize.
             in_axis (int | None | Callable): Specify which axes of the bijection
@@ -259,7 +262,7 @@ def _infer_axis_size_from_params(tree, in_axis):
 
 
 def _resolve_vmapped_axes(pytree, in_axes):
-    "Returns pytree with ints denoting vmapped dimensions."
+    """Returns pytree with ints denoting vmapped dimensions."""
 
     # Adapted from equinox filter_vmap
     def _resolve_axis(in_axes, elem):

--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -211,7 +211,7 @@ class Vmap(AbstractBijection):
             return bijection.transform(x, condition)
 
         return eqx.filter_vmap(_transform, in_axes=self.in_axes)(
-            self.bijection, x, condition
+            self.bijection, x, condition,
         )
 
     def transform_and_log_det(self, x, condition=None):
@@ -221,7 +221,7 @@ class Vmap(AbstractBijection):
             return bijection.transform_and_log_det(x, condition)
 
         y, log_det = eqx.filter_vmap(_transform_and_log_det, in_axes=self.in_axes)(
-            self.bijection, x, condition
+            self.bijection, x, condition,
         )
         return y, jnp.sum(log_det)
 
@@ -232,7 +232,7 @@ class Vmap(AbstractBijection):
             return bijection.inverse(x, condition)
 
         return eqx.filter_vmap(_inverse, in_axes=self.in_axes)(
-            self.bijection, y, condition
+            self.bijection, y, condition,
         )
 
     def inverse_and_log_det(self, y, condition=None):
@@ -242,7 +242,7 @@ class Vmap(AbstractBijection):
             return bijection.inverse_and_log_det(x, condition)
 
         x, log_det = eqx.filter_vmap(_inverse_and_log_det, in_axes=self.in_axes)(
-            self.bijection, y, condition
+            self.bijection, y, condition,
         )
         return x, jnp.sum(log_det)
 
@@ -254,7 +254,7 @@ def _infer_axis_size_from_params(tree, in_axis):
             lambda leaf, ax: leaf.shape[ax] if ax is not None else None,
             tree,
             axes,
-        )
+        ),
     )
     if len(axis_sizes) == 0:
         raise ValueError("in_axis did not map to any leaves to vectorize.")

--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -123,15 +123,18 @@ class Vmap(AbstractBijection):
             (10,)
 
         A more advanced use case is to create bijections with more fine grained control
-        over parameter broadcasting. For example, ``Affine`` broadcasts the location and
-        scale parameters. What if we want an ``Affine`` bijection, with a global scale
-        parameter, but an elementwise location parameter? We could achieve this as
-        follows
+        over parameter broadcasting. For example, the ``Affine`` constructor broadcasts
+        the location and scale parameters during initialization. What if we want an
+        ``Affine`` bijection, with a global scale parameter, but an elementwise location
+        parameter? We could achieve this as follows.
 
+            >>> from jax.tree_util import tree_map
             >>> bijection = Affine(jnp.zeros(()), jnp.ones(()))
             >>> bijection = eqx.tree_at(lambda bij: bij.loc, bijection, jnp.arange(3))
             >>> in_axis = tree_map(lambda _: None, bijection)
-            >>> in_axis = eqx.tree_at(lambda bij: bij.loc, in_axis, 0, is_leaf=lambda x: x is None)
+            >>> in_axis = eqx.tree_at(
+            ...     lambda bij: bij.loc, in_axis, 0, is_leaf=lambda x: x is None
+            ...     )
             >>> bijection = Vmap(bijection, in_axis=in_axis)
             >>> bijection.shape
             (3,)

--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -211,7 +211,9 @@ class Vmap(AbstractBijection):
             return bijection.transform(x, condition)
 
         return eqx.filter_vmap(_transform, in_axes=self.in_axes)(
-            self.bijection, x, condition,
+            self.bijection,
+            x,
+            condition,
         )
 
     def transform_and_log_det(self, x, condition=None):
@@ -221,7 +223,9 @@ class Vmap(AbstractBijection):
             return bijection.transform_and_log_det(x, condition)
 
         y, log_det = eqx.filter_vmap(_transform_and_log_det, in_axes=self.in_axes)(
-            self.bijection, x, condition,
+            self.bijection,
+            x,
+            condition,
         )
         return y, jnp.sum(log_det)
 
@@ -232,7 +236,9 @@ class Vmap(AbstractBijection):
             return bijection.inverse(x, condition)
 
         return eqx.filter_vmap(_inverse, in_axes=self.in_axes)(
-            self.bijection, y, condition,
+            self.bijection,
+            y,
+            condition,
         )
 
     def inverse_and_log_det(self, y, condition=None):
@@ -242,7 +248,9 @@ class Vmap(AbstractBijection):
             return bijection.inverse_and_log_det(x, condition)
 
         x, log_det = eqx.filter_vmap(_inverse_and_log_det, in_axes=self.in_axes)(
-            self.bijection, y, condition,
+            self.bijection,
+            y,
+            condition,
         )
         return x, jnp.sum(log_det)
 

--- a/flowjax/bijections/masked_autoregressive.py
+++ b/flowjax/bijections/masked_autoregressive.py
@@ -17,9 +17,14 @@ from flowjax.utils import get_ravelled_bijection_constructor
 
 
 class MaskedAutoregressive(AbstractBijection):
-    """Masked autoregressive bijection implementation (https://arxiv.org/abs/1705.07057v4).
+    """Masked autoregressive bijection.
+
     The transformer is parameterised by a neural network, with weights masked to ensure
     an autoregressive structure.
+
+    Ref:
+        - https://arxiv.org/abs/1705.07057v4
+        - https://arxiv.org/abs/1705.07057v4
     """
 
     shape: tuple[int, ...]
@@ -37,11 +42,12 @@ class MaskedAutoregressive(AbstractBijection):
         nn_depth: int,
         nn_activation: Callable = jnn.relu,
     ) -> None:
-        """
+        """Initialize the masked autoregressive bijection.
+
         Args:
             key (KeyArray): Jax PRNGKey
-            transformer (AbstractBijection): Bijection with shape () to be parameterised by the
-                autoregressive network.
+            transformer (AbstractBijection): Bijection with shape () to be parameterised
+            by the autoregressive network.
             dim (int): Dimension.
             cond_dim (int | None): Dimension of any conditioning variables.
             nn_width (int): Neural network width.

--- a/flowjax/bijections/masked_autoregressive.py
+++ b/flowjax/bijections/masked_autoregressive.py
@@ -1,7 +1,7 @@
 """Masked autoregressive network and bijection."""
 
+from collections.abc import Callable
 from functools import partial
-from typing import Callable
 
 import equinox as eqx
 import jax
@@ -129,7 +129,7 @@ class MaskedAutoregressive(AbstractBijection):
 
     def _flat_params_to_transformer(self, params: Array):
         """Reshape to dim X params_per_dim, then vmap."""
-        dim = self.shape[-1]  # type: ignore
+        dim = self.shape[-1]
         transformer_params = jnp.reshape(params, (dim, -1))
         transformer = eqx.filter_vmap(self.transformer_constructor)(transformer_params)
         return Vmap(transformer, in_axis=eqx.if_array(0))

--- a/flowjax/bijections/masked_autoregressive.py
+++ b/flowjax/bijections/masked_autoregressive.py
@@ -11,12 +11,12 @@ from jax import Array
 from jax.random import KeyArray
 
 from flowjax.bijections.bijection import AbstractBijection
-from flowjax.bijections.jax_transforms import Batch
+from flowjax.bijections.jax_transforms import Vmap
 from flowjax.nn import AutoregressiveMLP
 from flowjax.utils import get_ravelled_bijection_constructor
 
 
-class MaskedAutoregressive(AbstractBijection, strict=True):
+class MaskedAutoregressive(AbstractBijection):
     """Masked autoregressive bijection implementation (https://arxiv.org/abs/1705.07057v4).
     The transformer is parameterised by a neural network, with weights masked to ensure
     an autoregressive structure.
@@ -126,4 +126,4 @@ class MaskedAutoregressive(AbstractBijection, strict=True):
         dim = self.shape[-1]  # type: ignore
         transformer_params = jnp.reshape(params, (dim, -1))
         transformer = eqx.filter_vmap(self.transformer_constructor)(transformer_params)
-        return Batch(transformer, (dim,), vectorize_bijection=True)
+        return Vmap(transformer, in_axis=eqx.if_array(0))

--- a/flowjax/bijections/masked_autoregressive.py
+++ b/flowjax/bijections/masked_autoregressive.py
@@ -56,11 +56,11 @@ class MaskedAutoregressive(AbstractBijection):
         """
         if transformer.shape != () or transformer.cond_shape is not None:
             raise ValueError(
-                "Only unconditional transformers with shape () are supported."
+                "Only unconditional transformers with shape () are supported.",
             )
 
         constructor, transformer_init_params = get_ravelled_bijection_constructor(
-            transformer
+            transformer,
         )
 
         if cond_dim is None:
@@ -85,7 +85,7 @@ class MaskedAutoregressive(AbstractBijection):
 
         # Initialise bias terms to match the provided transformer parameters
         self.autoregressive_mlp = eqx.tree_at(
-            where=lambda t: t.layers[-1].linear.bias,  # type: ignore
+            where=lambda t: t.layers[-1].linear.bias,
             pytree=autoregressive_mlp,
             replace=jnp.tile(transformer_init_params, dim),
         )

--- a/flowjax/bijections/masked_autoregressive.py
+++ b/flowjax/bijections/masked_autoregressive.py
@@ -10,25 +10,27 @@ import jax.numpy as jnp
 from jax import Array
 from jax.random import KeyArray
 
-from flowjax.bijections.bijection import Bijection
+from flowjax.bijections.bijection import AbstractBijection
 from flowjax.bijections.jax_transforms import Batch
 from flowjax.nn import AutoregressiveMLP
 from flowjax.utils import get_ravelled_bijection_constructor
 
 
-class MaskedAutoregressive(Bijection):
+class MaskedAutoregressive(AbstractBijection, strict=True):
     """Masked autoregressive bijection implementation (https://arxiv.org/abs/1705.07057v4).
     The transformer is parameterised by a neural network, with weights masked to ensure
     an autoregressive structure.
     """
 
+    shape: tuple[int, ...]
+    cond_shape: tuple[int, ...] | None
     transformer_constructor: Callable
     autoregressive_mlp: AutoregressiveMLP
 
     def __init__(
         self,
         key: KeyArray,
-        transformer: Bijection,
+        transformer: AbstractBijection,
         dim: int,
         cond_dim: int | None,
         nn_width: int,

--- a/flowjax/bijections/masked_autoregressive.py
+++ b/flowjax/bijections/masked_autoregressive.py
@@ -40,7 +40,7 @@ class MaskedAutoregressive(AbstractBijection):
         """
         Args:
             key (KeyArray): Jax PRNGKey
-            transformer (Bijection): Bijection with shape () to be parameterised by the
+            transformer (AbstractBijection): Bijection with shape () to be parameterised by the
                 autoregressive network.
             dim (int): Dimension.
             cond_dim (int | None): Dimension of any conditioning variables.

--- a/flowjax/bijections/planar.py
+++ b/flowjax/bijections/planar.py
@@ -30,7 +30,7 @@ class Planar(AbstractBijection):
 
     def __init__(
         self,
-        key: jr.KeyArray,
+        key: Array,
         dim: int,
         cond_dim: int | None = None,
         **mlp_kwargs,
@@ -38,7 +38,7 @@ class Planar(AbstractBijection):
         """Initialize the bijection.
 
         Args:
-            key (jr.KeyArray): Jax random seed.
+            key (Array): Jax random seed.
             dim (int): Dimension of the bijection.
             cond_dim (int | None, optional): Dimension of extra conditioning variables.
                 Defaults to None.

--- a/flowjax/bijections/planar.py
+++ b/flowjax/bijections/planar.py
@@ -53,7 +53,7 @@ class Planar(AbstractBijection):
             self.cond_shape = None
         else:
             self.params = None
-            self.conditioner = eqx.nn.MLP(dim, 2 * dim + 1, **mlp_kwargs, key=key)
+            self.conditioner = eqx.nn.MLP(cond_dim, 2 * dim + 1, **mlp_kwargs, key=key)
             self.cond_shape = (cond_dim,)
 
     def transform(self, x, condition=None):

--- a/flowjax/bijections/planar.py
+++ b/flowjax/bijections/planar.py
@@ -1,5 +1,6 @@
-"""Planar transform, i.e. a layer in a planar flow introduced in
-https://arxiv.org/pdf/1505.05770.pdf.
+"""Planar transform.
+
+A layer in a planar flow introduced in https://arxiv.org/pdf/1505.05770.pdf.
 """
 
 from typing import ClassVar
@@ -15,8 +16,9 @@ from flowjax.bijections import AbstractBijection
 
 
 class Planar(AbstractBijection):
-    r"""Planar bijection as used by https://arxiv.org/pdf/1505.05770.pdf. Uses the
-    transformation :math:`y + u \cdot \text{tanh}(w \cdot x + b)`, where
+    r"""Planar bijection as used by https://arxiv.org/pdf/1505.05770.pdf.
+
+    Uses the transformation :math:`y + u \cdot \text{tanh}(w \cdot x + b)`, where
     :math:`u \in \mathbb{R}^D, \ w \in \mathbb{R}^D` and :math:`b \in \mathbb{R}`. In
     the unconditional case, :math:`w`, :math:`u`  and :math:`b` are learned directly.
     In the conditional case they are parameterised by an MLP.
@@ -33,14 +35,15 @@ class Planar(AbstractBijection):
         cond_dim: int | None = None,
         **mlp_kwargs,
     ):
-        """
+        """Initialize the bijection.
+
         Args:
             key (jr.KeyArray): Jax random seed.
             dim (int): Dimension of the bijection.
             cond_dim (int | None, optional): Dimension of extra conditioning variables.
                 Defaults to None.
-            **mlp_kwargs: Key word arguments passed to the MLP conditioner. Ignored
-                when cond_dim is None.
+            **mlp_kwargs: Key word arguments (excluding in_size and out_size) passed to
+                the MLP (equinox.nn.MLP). Ignored when cond_dim is None.
         """
         self.shape = (dim,)
 
@@ -68,7 +71,7 @@ class Planar(AbstractBijection):
         return self.get_planar(condition).inverse_and_log_det(y)
 
     def get_planar(self, condition=None):
-        "Get the planar bijection with the conditioning applied if conditional."
+        """Get the planar bijection with the conditioning applied if conditional."""
         if self.cond_shape is not None:
             params = self.conditioner(condition)
         else:
@@ -88,9 +91,11 @@ class _UnconditionalPlanar(AbstractBijection):
     bias: Array
 
     def __init__(self, weight, act_scale, bias):
-        """Construct an unconditional planar bijection. Note act_scale (u in the paper)
-        is unconstrained and the constraint to ensure invertiblitiy is applied in the
-        ``get_act_scale``."""
+        """Construct an unconditional planar bijection.
+
+        Note act_scale (u in the paper) is unconstrained and the constraint to ensure
+        invertiblitiy is applied in the ``get_act_scale``.
+        """
         self.weight = weight
         self._act_scale = act_scale
         self.bias = bias
@@ -108,8 +113,10 @@ class _UnconditionalPlanar(AbstractBijection):
         return y, log_det
 
     def get_act_scale(self):
-        """Apply constraint to u to ensure invertibility. See appendix A1 in
-        https://arxiv.org/pdf/1505.05770.pdf."""
+        """Apply constraint to u to ensure invertibility.
+
+        See appendix A1 in https://arxiv.org/pdf/1505.05770.pdf.
+        """
         wtu = self._act_scale @ self.weight
         m_wtu = -1 + jnp.log(1 + softplus(wtu))
         u = self._act_scale + (m_wtu - wtu) * self.weight / norm(self.weight) ** 2

--- a/flowjax/bijections/planar.py
+++ b/flowjax/bijections/planar.py
@@ -119,15 +119,14 @@ class _UnconditionalPlanar(AbstractBijection):
         """
         wtu = self._act_scale @ self.weight
         m_wtu = -1 + jnp.log(1 + softplus(wtu))
-        u = self._act_scale + (m_wtu - wtu) * self.weight / norm(self.weight) ** 2
-        return u
+        return self._act_scale + (m_wtu - wtu) * self.weight / norm(self.weight) ** 2
 
     def inverse(self, y, condition=None):
         raise NotImplementedError(
-            "The inverse planar transformation is not implemented."
+            "The inverse planar transformation is not implemented.",
         )
 
     def inverse_and_log_det(self, y, condition=None):
         raise NotImplementedError(
-            "The inverse planar transformation is not implemented."
+            "The inverse planar transformation is not implemented.",
         )

--- a/flowjax/bijections/planar.py
+++ b/flowjax/bijections/planar.py
@@ -14,7 +14,7 @@ from jax.numpy.linalg import norm
 from flowjax.bijections import AbstractBijection
 
 
-class Planar(AbstractBijection, strict=True):
+class Planar(AbstractBijection):
     r"""Planar bijection as used by https://arxiv.org/pdf/1505.05770.pdf. Uses the
     transformation :math:`y + u \cdot \text{tanh}(w \cdot x + b)`, where
     :math:`u \in \mathbb{R}^D, \ w \in \mathbb{R}^D` and :math:`b \in \mathbb{R}`. In
@@ -78,7 +78,7 @@ class Planar(AbstractBijection, strict=True):
         return _UnconditionalPlanar(w, u, bias)
 
 
-class _UnconditionalPlanar(AbstractBijection, strict=True):
+class _UnconditionalPlanar(AbstractBijection):
     """Unconditional planar bijection, used in Planar."""
 
     shape: tuple[int, ...]

--- a/flowjax/bijections/rational_quadratic_spline.py
+++ b/flowjax/bijections/rational_quadratic_spline.py
@@ -51,14 +51,14 @@ class RationalQuadraticSpline(AbstractBijection):
         self.unbounded_x_pos = jnp.zeros(knots)
         self.unbounded_y_pos = jnp.zeros(knots)
         self.unbounded_derivatives = jnp.full(
-            knots + 2, jnp.log(jnp.exp(1 - min_derivative) - 1)
+            knots + 2, jnp.log(jnp.exp(1 - min_derivative) - 1),
         )
 
     @property
     def x_pos(self):
         """Get the knot x positions."""
         x_pos = real_to_increasing_on_interval(
-            self.unbounded_x_pos, self.interval, self.softmax_adjust
+            self.unbounded_x_pos, self.interval, self.softmax_adjust,
         )
         return jnp.pad(x_pos, 1, constant_values=(-self.interval, self.interval))
 
@@ -66,7 +66,7 @@ class RationalQuadraticSpline(AbstractBijection):
     def y_pos(self):
         """Get the knot y positions."""
         y_pos = real_to_increasing_on_interval(
-            self.unbounded_y_pos, self.interval, self.softmax_adjust
+            self.unbounded_y_pos, self.interval, self.softmax_adjust,
         )
         return jnp.pad(y_pos, 1, constant_values=(-self.interval, self.interval))
 

--- a/flowjax/bijections/rational_quadratic_spline.py
+++ b/flowjax/bijections/rational_quadratic_spline.py
@@ -134,4 +134,4 @@ class RationalQuadraticSpline(AbstractBijection):
         num = sk**2 * (dk1 * xi**2 + 2 * sk * xi * (1 - xi) + dk * (1 - xi) ** 2)
         den = (sk + (dk1 + dk - 2 * sk) * xi * (1 - xi)) ** 2
         derivative = num / den
-        return jnp.where(in_bounds, derivative, 1.0)  # type: ignore
+        return jnp.where(in_bounds, derivative, 1.0)

--- a/flowjax/bijections/rational_quadratic_spline.py
+++ b/flowjax/bijections/rational_quadratic_spline.py
@@ -31,6 +31,17 @@ class RationalQuadraticSpline(AbstractBijection):
         min_derivative: float = 1e-3,
         softmax_adjust: float = 1e-2,
     ):
+        """Initialize the RationalQuadraticSpline bijection.
+
+        Args:
+            knots (int): Number of knots.
+            interval (float): interval to transform, [-interval, interval].
+            min_derivative (float): Minimum dervivative. Defaults to 1e-3.
+            softmax_adjust (float): Controls minimum bin width and height by
+                rescaling softmax output, e.g. 0=no adjustment, 1=average softmax output
+                with evenly spaced widths, >1 promotes more evenly spaced widths.
+                See ``real_to_increasing_on_interval``. Defaults to 1e-2.
+        """
         self.knots = knots
         self.interval = interval
         self.softmax_adjust = softmax_adjust

--- a/flowjax/bijections/rational_quadratic_spline.py
+++ b/flowjax/bijections/rational_quadratic_spline.py
@@ -51,14 +51,17 @@ class RationalQuadraticSpline(AbstractBijection):
         self.unbounded_x_pos = jnp.zeros(knots)
         self.unbounded_y_pos = jnp.zeros(knots)
         self.unbounded_derivatives = jnp.full(
-            knots + 2, jnp.log(jnp.exp(1 - min_derivative) - 1),
+            knots + 2,
+            jnp.log(jnp.exp(1 - min_derivative) - 1),
         )
 
     @property
     def x_pos(self):
         """Get the knot x positions."""
         x_pos = real_to_increasing_on_interval(
-            self.unbounded_x_pos, self.interval, self.softmax_adjust,
+            self.unbounded_x_pos,
+            self.interval,
+            self.softmax_adjust,
         )
         return jnp.pad(x_pos, 1, constant_values=(-self.interval, self.interval))
 
@@ -66,7 +69,9 @@ class RationalQuadraticSpline(AbstractBijection):
     def y_pos(self):
         """Get the knot y positions."""
         y_pos = real_to_increasing_on_interval(
-            self.unbounded_y_pos, self.interval, self.softmax_adjust,
+            self.unbounded_y_pos,
+            self.interval,
+            self.softmax_adjust,
         )
         return jnp.pad(y_pos, 1, constant_values=(-self.interval, self.interval))
 

--- a/flowjax/bijections/softplus.py
+++ b/flowjax/bijections/softplus.py
@@ -1,16 +1,16 @@
 """SoftPlus bijection"""
+from typing import ClassVar
+
 import jax.numpy as jnp
 from jax.nn import softplus
 
-from flowjax.bijections.bijection import Bijection
+from flowjax.bijections.bijection import AbstractBijection
 
 
-class SoftPlus(Bijection):
+class SoftPlus(AbstractBijection, strict=True):
     r"""Transforms to positive domain using softplus :math:`y = \log(1 + \exp(x))`."""
-
-    def __init__(self, shape: tuple[int] = ()):
-        self.shape = shape
-        self.cond_shape = None
+    shape: tuple[int, ...] = ()
+    cond_shape: ClassVar[None] = None
 
     def transform(self, x, condition=None):
         x, _ = self._argcheck_and_cast(x)

--- a/flowjax/bijections/softplus.py
+++ b/flowjax/bijections/softplus.py
@@ -1,4 +1,4 @@
-"""SoftPlus bijection"""
+"""SoftPlus bijection."""
 from typing import ClassVar
 
 import jax.numpy as jnp

--- a/flowjax/bijections/softplus.py
+++ b/flowjax/bijections/softplus.py
@@ -7,7 +7,7 @@ from jax.nn import softplus
 from flowjax.bijections.bijection import AbstractBijection
 
 
-class SoftPlus(AbstractBijection, strict=True):
+class SoftPlus(AbstractBijection):
     r"""Transforms to positive domain using softplus :math:`y = \log(1 + \exp(x))`."""
     shape: tuple[int, ...] = ()
     cond_shape: ClassVar[None] = None

--- a/flowjax/bijections/tanh.py
+++ b/flowjax/bijections/tanh.py
@@ -1,28 +1,27 @@
 """Tanh bijection."""
 import math
 import warnings
+from typing import ClassVar
 
 import jax.numpy as jnp
 from jax.nn import softplus
 
-from flowjax.bijections.bijection import Bijection
+from flowjax.bijections.bijection import AbstractBijection
 
 
 def _tanh_log_grad(x):
-    """log gradient vector of tanh transformation."""
+    """log gradient vector of tanh transformation.
+    Args:
+        shape (tuple[int, ...] | None): Shape of the bijection. Defaults to None.
+    """
     return -2 * (x + softplus(-2 * x) - jnp.log(2.0))
 
 
-class Tanh(Bijection):
+class Tanh(AbstractBijection, strict=True):
     """Tanh bijection."""
 
-    def __init__(self, shape: tuple[int, ...] = ()) -> None:
-        """
-        Args:
-            shape (tuple[int, ...] | None): Shape of the bijection. Defaults to None.
-        """
-        self.shape = shape
-        self.cond_shape = None
+    shape: tuple[int, ...] = ()
+    cond_shape: ClassVar[None] = None
 
     def transform(self, x, condition=None):
         x, _ = self._argcheck_and_cast(x)
@@ -42,7 +41,7 @@ class Tanh(Bijection):
         return x, -jnp.sum(_tanh_log_grad(x))
 
 
-class LeakyTanh(Bijection):
+class LeakyTanh(AbstractBijection, strict=True):
     """
     Tanh bijection, with a linear transformation beyond +/- max_val. The value and
     gradient of the linear segments are set to match tanh at +/- max_val. This bijection
@@ -51,6 +50,8 @@ class LeakyTanh(Bijection):
     is not appropriate.
     """
 
+    shape: tuple[int, ...] = ()
+    cond_shape: ClassVar[None] = None
     max_val: float
     intercept: float
     linear_grad: float
@@ -65,7 +66,6 @@ class LeakyTanh(Bijection):
         self.linear_grad = math.exp(_tanh_log_grad(max_val))
         self.intercept = math.tanh(max_val) - self.linear_grad * max_val
         self.shape = shape
-        self.cond_shape = None
 
     def transform(self, x, condition=None):
         x, _ = self._argcheck_and_cast(x)

--- a/flowjax/bijections/tanh.py
+++ b/flowjax/bijections/tanh.py
@@ -76,7 +76,7 @@ class LeakyTanh(AbstractBijection):
         x, _ = self._argcheck_and_cast(x)
         y = self.transform(x)
         log_grads = jnp.where(
-            jnp.abs(x) >= self.max_val, jnp.log(self.linear_grad), _tanh_log_grad(x)
+            jnp.abs(x) >= self.max_val, jnp.log(self.linear_grad), _tanh_log_grad(x),
         )
         return y, jnp.sum(log_grads)
 

--- a/flowjax/bijections/tanh.py
+++ b/flowjax/bijections/tanh.py
@@ -17,7 +17,7 @@ def _tanh_log_grad(x):
     return -2 * (x + softplus(-2 * x) - jnp.log(2.0))
 
 
-class Tanh(AbstractBijection, strict=True):
+class Tanh(AbstractBijection):
     """Tanh bijection."""
 
     shape: tuple[int, ...] = ()
@@ -41,7 +41,7 @@ class Tanh(AbstractBijection, strict=True):
         return x, -jnp.sum(_tanh_log_grad(x))
 
 
-class LeakyTanh(AbstractBijection, strict=True):
+class LeakyTanh(AbstractBijection):
     """
     Tanh bijection, with a linear transformation beyond +/- max_val. The value and
     gradient of the linear segments are set to match tanh at +/- max_val. This bijection

--- a/flowjax/bijections/tanh.py
+++ b/flowjax/bijections/tanh.py
@@ -1,6 +1,5 @@
 """Tanh bijection."""
 import math
-import warnings
 from typing import ClassVar
 
 import jax.numpy as jnp

--- a/flowjax/bijections/tanh.py
+++ b/flowjax/bijections/tanh.py
@@ -98,13 +98,3 @@ class LeakyTanh(AbstractBijection):
             _tanh_log_grad(x),
         )
         return x, -jnp.sum(log_grads)
-
-
-def TanhLinearTails(*args, **kwargs):
-    """Deprecated version of LeakyTanh."""
-    warnings.warn(
-        "This class has been renamed to LeakyTanh and TanhLinearTails will be removed. "
-        "please update to the new name.",
-        stacklevel=2,
-    )
-    return LeakyTanh(*args, **kwargs)

--- a/flowjax/bijections/tanh.py
+++ b/flowjax/bijections/tanh.py
@@ -10,10 +10,7 @@ from flowjax.bijections.bijection import AbstractBijection
 
 
 def _tanh_log_grad(x):
-    """log gradient vector of tanh transformation.
-    Args:
-        shape (tuple[int, ...] | None): Shape of the bijection. Defaults to None.
-    """
+    # Log gradient vector of tanh transformation.
     return -2 * (x + softplus(-2 * x) - jnp.log(2.0))
 
 
@@ -42,12 +39,12 @@ class Tanh(AbstractBijection):
 
 
 class LeakyTanh(AbstractBijection):
-    """
-    Tanh bijection, with a linear transformation beyond +/- max_val. The value and
-    gradient of the linear segments are set to match tanh at +/- max_val. This bijection
-    can be useful to encourage values to be within an interval, whilst avoiding
-    numerical precision issues, or in cases we require a real -> real mapping so Tanh
-    is not appropriate.
+    """Tanh bijection, with a linear transformation beyond +/- max_val.
+
+    The value and gradient of the linear segments are set to match tanh at +/- max_val.
+    This bijection can be useful to encourage values to be within an interval, whilst
+    avoiding numerical precision issues, or in cases we require a real -> real mapping
+    so Tanh is not appropriate.
     """
 
     shape: tuple[int, ...] = ()
@@ -57,7 +54,8 @@ class LeakyTanh(AbstractBijection):
     linear_grad: float
 
     def __init__(self, max_val: float, shape: tuple[int, ...] = ()):
-        """
+        """Initialize the leaky tanh bijection.
+
         Args:
             max_val (float): Value above or below which the function becomes linear.
             shape (tuple[int, ...] | None): The shape of the bijection. Defaults to ().
@@ -101,6 +99,7 @@ class LeakyTanh(AbstractBijection):
 
 
 def TanhLinearTails(*args, **kwargs):
+    """Deprecated version of LeakyTanh."""
     warnings.warn(
         "This class has been renamed to LeakyTanh and TanhLinearTails will be removed. "
         "please update to the new name.",

--- a/flowjax/bijections/tanh.py
+++ b/flowjax/bijections/tanh.py
@@ -76,7 +76,9 @@ class LeakyTanh(AbstractBijection):
         x, _ = self._argcheck_and_cast(x)
         y = self.transform(x)
         log_grads = jnp.where(
-            jnp.abs(x) >= self.max_val, jnp.log(self.linear_grad), _tanh_log_grad(x),
+            jnp.abs(x) >= self.max_val,
+            jnp.log(self.linear_grad),
+            _tanh_log_grad(x),
         )
         return y, jnp.sum(log_grads)
 

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -1,4 +1,4 @@
-"""Utility bijections (embedding network, permutations, inversion etc.)"""
+"""Utility bijections (embedding network, permutations, inversion etc.)."""
 from typing import Callable, ClassVar
 
 import jax.numpy as jnp
@@ -10,7 +10,9 @@ from flowjax.bijections.bijection import AbstractBijection
 
 
 class Invert(AbstractBijection):
-    """Invert a bijection, such that the transform methods become the inverse
+    """Invert a bijection.
+
+    This wraps a bijection, such that the transform methods become the inverse
     methods and vice versa. Note that in general, we define bijections such that
     the forward methods are preffered, i.e. faster/actually implemented. For
     training flows, we generally want the inverse method (used in density
@@ -23,7 +25,8 @@ class Invert(AbstractBijection):
     bijection: AbstractBijection
 
     def __init__(self, bijection: AbstractBijection):
-        """
+        """Initialize the bijection.
+
         Args:
             bijection (AbstractBijection): Bijection to invert.
         """
@@ -53,7 +56,8 @@ class Permute(AbstractBijection):
     inverse_permutation: tuple[Array, ...]
 
     def __init__(self, permutation: ArrayLike):
-        """
+        """Initialize the permutation bijection.
+
         Args:
             permutation (ArrayLike): An array with shape matching the array to
                 transform, with elements 0-(array.size-1) representing the new order
@@ -129,12 +133,19 @@ class Partial(AbstractBijection):
     bijection: AbstractBijection
     idxs: int | slice | Array | tuple
 
-    def __init__(self, bijection: AbstractBijection, idxs, shape: tuple[int, ...]):
-        """
+    def __init__(
+        self,
+        bijection: AbstractBijection,
+        idxs: int | slice | Array | tuple,
+        shape: tuple[int, ...],
+    ):
+        """Initialize the bijection.
+
         Args:
-            bijection (AbstractBijection): Bijection that is compatible with the subset of x
-                indexed by idxs. idxs: Indices (Integer, a slice, or an ndarray with
-                integer/bool dtype) of the transformed portion.
+            bijection (AbstractBijection): Bijection that is compatible with the subset
+                of x indexed by idxs. idxs: Indices (Integer, a slice, or an ndarray
+                with integer/bool dtype) of the transformed portion.
+            idxs (int | slice | Array | tuple): The indexes to transform.
             shape (tuple[int, ...] | None): Shape of the bijection. Defaults to None.
         """
         self.bijection = bijection
@@ -171,7 +182,9 @@ class Partial(AbstractBijection):
 
 
 class EmbedCondition(AbstractBijection):
-    """Use an embedding network to reduce the dimensionality of the conditioning
+    """Wrap a bijection to include an embedding network.
+
+    Generally this is used to reduce the dimensionality of the conditioning
     variable. The returned bijection has cond_dim equal to the raw condition size.
     """
 
@@ -186,14 +199,15 @@ class EmbedCondition(AbstractBijection):
         embedding_net: Callable,
         raw_cond_shape: tuple[int, ...],
     ) -> None:
-        """
+        """Intialize the bijection.
+
         Args:
-            bijection (AbstractBijection): Bijection with ``bijection.cond_dim`` equal to the
-                embedded size.
+            bijection (AbstractBijection): Bijection with ``bijection.cond_dim`` equal
+            to the embedded size.
             embedding_net (Callable): A callable (e.g. equinox module) that embeds a
-                conditioning variable to size ``bijection.cond_dim``.
+            conditioning variable to size ``bijection.cond_dim``.
             raw_cond_shape (tuple[int, ...] | None): The dimension of the raw
-                conditioning variable.
+            conditioning variable.
         """
         self.bijection = bijection
         self.embedding_net = embedding_net

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -25,7 +25,7 @@ class Invert(AbstractBijection):
     def __init__(self, bijection: AbstractBijection):
         """
         Args:
-            bijection (Bijection): Bijection to invert.
+            bijection (AbstractBijection): Bijection to invert.
         """
         self.bijection = bijection
         self.shape = bijection.shape
@@ -132,7 +132,7 @@ class Partial(AbstractBijection):
     def __init__(self, bijection: AbstractBijection, idxs, shape: tuple[int, ...]):
         """
         Args:
-            bijection (Bijection): Bijection that is compatible with the subset of x
+            bijection (AbstractBijection): Bijection that is compatible with the subset of x
                 indexed by idxs. idxs: Indices (Integer, a slice, or an ndarray with
                 integer/bool dtype) of the transformed portion.
             shape (tuple[int, ...] | None): Shape of the bijection. Defaults to None.
@@ -188,7 +188,7 @@ class EmbedCondition(AbstractBijection):
     ) -> None:
         """
         Args:
-            bijection (Bijection): Bijection with ``bijection.cond_dim`` equal to the
+            bijection (AbstractBijection): Bijection with ``bijection.cond_dim`` equal to the
                 embedded size.
             embedding_net (Callable): A callable (e.g. equinox module) that embeds a
                 conditioning variable to size ``bijection.cond_dim``.

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -74,7 +74,7 @@ class Permute(AbstractBijection):
         self.permutation = tuple(jnp.reshape(i, permutation.shape) for i in indices)
 
         inv_indices = jnp.unravel_index(
-            jnp.argsort(permutation.ravel()), permutation.shape
+            jnp.argsort(permutation.ravel()), permutation.shape,
         )
         self.inverse_permutation = tuple(
             jnp.reshape(i, permutation.shape) for i in inv_indices
@@ -157,7 +157,7 @@ class Partial(AbstractBijection):
             raise ValueError(
                 f"The bijection shape is incompatible with the subset of the input "
                 f"indexed by 'idxs'. The bijection has a shape of {bijection.shape}, "
-                f"while the subset has a shape of {jnp.zeros(shape)[idxs].shape}."
+                f"while the subset has a shape of {jnp.zeros(shape)[idxs].shape}.",
             )
 
     def transform(self, x, condition=None):

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -1,5 +1,6 @@
 """Utility bijections (embedding network, permutations, inversion etc.)."""
-from typing import Callable, ClassVar
+from collections.abc import Callable
+from typing import ClassVar
 
 import jax.numpy as jnp
 from jax import Array

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -9,7 +9,7 @@ from jax.typing import ArrayLike
 from flowjax.bijections.bijection import AbstractBijection
 
 
-class Invert(AbstractBijection, strict=True):
+class Invert(AbstractBijection):
     """Invert a bijection, such that the transform methods become the inverse
     methods and vice versa. Note that in general, we define bijections such that
     the forward methods are preffered, i.e. faster/actually implemented. For
@@ -44,7 +44,7 @@ class Invert(AbstractBijection, strict=True):
         return self.bijection.transform_and_log_det(y, condition)
 
 
-class Permute(AbstractBijection, strict=True):
+class Permute(AbstractBijection):
     """Permutation transformation."""
 
     shape: tuple[int, ...]
@@ -93,7 +93,7 @@ class Permute(AbstractBijection, strict=True):
         return y[self.inverse_permutation], jnp.array(0)
 
 
-class Flip(AbstractBijection, strict=True):
+class Flip(AbstractBijection):
     """Flip the input array. Condition argument is ignored.
 
     Args:
@@ -121,7 +121,7 @@ class Flip(AbstractBijection, strict=True):
         return jnp.flip(y), jnp.array(0)
 
 
-class Partial(AbstractBijection, strict=True):
+class Partial(AbstractBijection):
     """Applies bijection to specific indices of an input."""
 
     shape: tuple[int, ...]
@@ -170,7 +170,7 @@ class Partial(AbstractBijection, strict=True):
         return y.at[self.idxs].set(x), log_det
 
 
-class EmbedCondition(AbstractBijection, strict=True):
+class EmbedCondition(AbstractBijection):
     """Use an embedding network to reduce the dimensionality of the conditioning
     variable. The returned bijection has cond_dim equal to the raw condition size.
     """

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -75,7 +75,8 @@ class Permute(AbstractBijection):
         self.permutation = tuple(jnp.reshape(i, permutation.shape) for i in indices)
 
         inv_indices = jnp.unravel_index(
-            jnp.argsort(permutation.ravel()), permutation.shape,
+            jnp.argsort(permutation.ravel()),
+            permutation.shape,
         )
         self.inverse_permutation = tuple(
             jnp.reshape(i, permutation.shape) for i in inv_indices

--- a/flowjax/distributions.py
+++ b/flowjax/distributions.py
@@ -45,7 +45,7 @@ class AbstractDistribution(eqx.Module):
         """
 
     @abstractmethod
-    def _sample(self, key: jr.KeyArray, condition: Array | None = None) -> Array:
+    def _sample(self, key: Array, condition: Array | None = None) -> Array:
         """Sample a point from the distribution.
 
         This method should return a single sample with shape matching
@@ -55,7 +55,7 @@ class AbstractDistribution(eqx.Module):
     @abstractmethod
     def _sample_and_log_prob(
         self,
-        key: jr.KeyArray,
+        key: Array,
         condition: Array | None = None,
     ) -> tuple[Array, Array]:
         """Sample a point from the distribution, and return its log probability."""
@@ -79,7 +79,7 @@ class AbstractDistribution(eqx.Module):
 
     def sample(
         self,
-        key: jr.KeyArray,
+        key: Array,
         sample_shape: tuple[int, ...] = (),
         condition: ArrayLike | None = None,
     ) -> Array:
@@ -92,7 +92,7 @@ class AbstractDistribution(eqx.Module):
         See the example for more information.
 
         Args:
-            key (jr.KeyArray): Jax random key.
+            key (Array): Jax random key.
             condition (ArrayLike | None): Conditioning variables. Defaults to None.
             sample_shape (tuple[int, ...]): Sample shape. Defaults to ().
 
@@ -154,7 +154,7 @@ class AbstractDistribution(eqx.Module):
 
     def sample_and_log_prob(
         self,
-        key: jr.KeyArray,
+        key: Array,
         sample_shape: tuple[int, ...] = (),
         condition: ArrayLike | None = None,
     ):
@@ -166,7 +166,7 @@ class AbstractDistribution(eqx.Module):
         more information.
 
         Args:
-            key (jr.KeyArray): Jax random key.
+            key (Array): Jax random key.
             condition (ArrayLike | None): Conditioning variables. Defaults to None.
             sample_shape (tuple[int, ...]): Sample shape. Defaults to ().
         """
@@ -283,7 +283,7 @@ class AbstractTransformed(AbstractDistribution):
         base_sample = self.base_dist._sample(key, condition)
         return self.bijection.transform(base_sample, condition)
 
-    def _sample_and_log_prob(self, key: jr.KeyArray, condition=None):
+    def _sample_and_log_prob(self, key: Array, condition=None):
         # We avoid computing the inverse transformation.
         base_sample, log_prob_base = self.base_dist._sample_and_log_prob(key, condition)
         sample, forward_log_dets = self.bijection.transform_and_log_det(

--- a/flowjax/distributions.py
+++ b/flowjax/distributions.py
@@ -69,7 +69,7 @@ class AbstractDistribution(eqx.Module):
 
     @abstractmethod
     def _sample_and_log_prob(
-        self, key: jr.KeyArray, condition: Array | None = None
+        self, key: jr.KeyArray, condition: Array | None = None,
     ) -> tuple[Array, Array]:
         """Sample a point from the distribution, and return its log probability."""
 
@@ -211,7 +211,7 @@ class AbstractDistribution(eqx.Module):
         if self.cond_shape is None:
             if condition is not None:
                 raise TypeError(
-                    f"Expected condition to be None; got {type(condition)}."
+                    f"Expected condition to be None; got {type(condition)}.",
                 )
             return None
         return arraylike_to_array(condition, err_name="condition")
@@ -241,7 +241,7 @@ class AbstractDistribution(eqx.Module):
                     if arg.shape != in_shape:
                         raise ValueError(
                             f"Expected trailing dimensions matching {in_shape} for "
-                            f"{name}; got {arg.shape}."
+                            f"{name}; got {arg.shape}.",
                         )
                 return method(*args)
 
@@ -288,7 +288,7 @@ class AbstractTransformed(AbstractDistribution):
         # We avoid computing the inverse transformation.
         base_sample, log_prob_base = self.base_dist._sample_and_log_prob(key, condition)
         sample, forward_log_dets = self.bijection.transform_and_log_det(
-            base_sample, condition
+            base_sample, condition,
         )
         return sample, log_prob_base - forward_log_dets
 
@@ -303,7 +303,7 @@ class AbstractTransformed(AbstractDistribution):
                     "The base distribution and bijection are both conditional "
                     "but have mismatched cond_shape attributes. Base distribution has"
                     f"{self.base_dist.cond_shape}, and the bijection has"
-                    f"{self.bijection.cond_shape}."
+                    f"{self.bijection.cond_shape}.",
                 )
 
     def merge_transforms(self):
@@ -367,7 +367,7 @@ class Transformed(AbstractTransformed):
         self.bijection = bijection
         self.shape = self.base_dist.shape
         self.cond_shape = merge_cond_shapes(
-            (self.bijection.cond_shape, self.base_dist.cond_shape)
+            (self.bijection.cond_shape, self.base_dist.cond_shape),
         )
 
 
@@ -665,7 +665,7 @@ class SpecializeCondition(AbstractDistribution):  # TODO check tested
         if self.dist.cond_shape != condition.shape:
             raise ValueError(
                 f"Expected condition shape {self.dist.cond_shape}, got "
-                f"{condition.shape}"
+                f"{condition.shape}",
             )
         self.dist = dist
         self._condition = condition

--- a/flowjax/distributions.py
+++ b/flowjax/distributions.py
@@ -194,8 +194,7 @@ class AbstractDistribution(eqx.Module):
             leading_cond_shape = ()
         key_shape = sample_shape + leading_cond_shape
         key_size = max(1, prod(key_shape))  # Still need 1 key for scalar sample
-        keys = jnp.reshape(jr.split(key, key_size), key_shape + (2,))
-        return keys
+        return jnp.reshape(jr.split(key, key_size), (*key_shape, 2))
 
     @property
     def ndim(self):
@@ -294,17 +293,16 @@ class AbstractTransformed(AbstractDistribution):
 
     def __check_init__(self):  # TODO test errors and test conditional base distribution
         """Checks cond_shape is compatible in both bijection and distribution."""
-        if (
-            self.base_dist.cond_shape is not None
-            and self.bijection.cond_shape is not None
-        ):
-            if self.base_dist.cond_shape != self.bijection.cond_shape:
-                raise ValueError(
-                    "The base distribution and bijection are both conditional "
-                    "but have mismatched cond_shape attributes. Base distribution has"
-                    f"{self.base_dist.cond_shape}, and the bijection has"
-                    f"{self.bijection.cond_shape}.",
-                )
+        if (self.base_dist.cond_shape is not None and
+            self.bijection.cond_shape is not None and
+            self.base_dist.cond_shape != self.bijection.cond_shape):
+
+            raise ValueError(
+                "The base distribution and bijection are both conditional "
+                "but have mismatched cond_shape attributes. Base distribution has"
+                f"{self.base_dist.cond_shape}, and the bijection has"
+                f"{self.bijection.cond_shape}.",
+            )
 
     def merge_transforms(self):
         """Unnests nested transformed distributions.

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -1,0 +1,133 @@
+"""
+Interfacing with numpyro
+==========================
+
+``flowjax.experimental.numpyro`` contains utilities to facilitate interfacing with
+numpyro. Note these utilities require numpyro to be installed."""
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jax.typing import ArrayLike
+
+try:
+    import numpyro
+except ImportError as e:
+    e.add_note(
+        "Note, in order to interface with numpyro, it must be installed. Please see "
+        "https://num.pyro.ai/en/latest/getting_started.html#installation"
+    )
+    raise
+
+from numpyro.distributions import constraints
+
+from flowjax.bijections import AbstractBijection
+from flowjax.distributions import Transformed
+from flowjax.utils import _get_ufunc_signature
+
+# TODO list:
+#    - How to support of batch dimensions.
+#    - Handle conditioning with a batch dimension?
+#    - Do I need to support non-transformed distributions?
+#    - Allow control of supports and constraints - will applications of transformations
+# to apply constraints lead to problems with reparameterisation?
+
+
+class VectorizedBijection(eqx.Module, strict=True):
+    "Wrap a flowjax bijection to support vectorization."
+
+    def __init__(self, bijection: AbstractBijection):
+        """
+        Args:
+            bijection (Bijection): flowjax bijection to be wrapped.
+            domain (constraints.Constraint, optional): Numpyro constraint.
+                Defaults to constraints.real.
+        """
+        self.bijection = bijection
+        self.shape = self.bijection.shape
+        self.cond_shape = self.bijection.cond_shape
+
+    def transform(self, x, condition=None):
+        transform = self.vectorize(self.bijection.transform)
+        return transform(x, condition)
+
+    def inverse(self, y, condition=None):
+        inverse = self.vectorize(self.bijection.inverse)
+        return inverse(y, condition)
+
+    def transform_and_log_det(self, x, condition=None):
+        transform_and_log_det = self.vectorize(
+            self.bijection.transform_and_log_det, log_det=True
+        )
+        return transform_and_log_det(x, condition)
+
+    def vectorize(self, func, log_det=False):
+        in_shapes, out_shapes = [self.bijection.shape], [self.bijection.shape]
+        if log_det:
+            out_shapes.append(())
+        if self.bijection.cond_shape is not None:
+            in_shapes.append(self.bijection.cond_shape)
+            exclude = frozenset()
+        else:
+            exclude = frozenset([1])
+        sig = _get_ufunc_signature(in_shapes, out_shapes)
+        return jnp.vectorize(func, signature=sig, excluded=exclude)
+
+
+class TransformedToNumpyro(numpyro.distributions.Distribution):
+    """Convert a Transformed flowjax distribution to a numpyro distribution."""
+
+    def __init__(
+        self,
+        dist: Transformed,
+        condition: ArrayLike | None = None,
+        support: constraints.Constraint = constraints.real,
+    ):
+        condition = dist._argcheck_and_cast_condition(condition)
+        if condition is not None:
+            batch_shape = (
+                condition.shape[: -len(dist.cond_shape)] if dist.cond_ndim > 0 else ()
+            )
+        else:
+            batch_shape = ()
+
+        self.dist = dist.merge_transforms()  # Ensure base distribution not transformed
+        self._condition = condition
+        self.support = support
+        super().__init__(batch_shape=batch_shape, event_shape=dist.shape)
+
+    def sample(self, key, sample_shape=...):
+        return self.dist.sample(key, sample_shape, self.condition)
+
+    def sample_with_intermediates(self, key, sample_shape=...):
+        z = self.dist.base_dist.sample(key, sample_shape, self.base_condition)
+        x = VectorizedBijection(self.dist.bijection).transform(z, self.condition)
+        return x, [z]
+
+    def log_prob(self, value, intermediates=None):
+        if intermediates is None:
+            return self.dist.log_prob(value, self.condition)
+        else:
+            z = intermediates[0]
+            _, log_det = VectorizedBijection(self.dist.bijection).transform_and_log_det(
+                z, self.condition
+            )
+            return self.dist.base_dist.log_prob(z, self.base_condition) - log_det
+
+    @property
+    def condition(self):
+        return jax.lax.stop_gradient(self._condition)
+
+    @property
+    def base_condition(self):
+        return self.condition if self.dist.base_dist.cond_shape else None
+
+
+def register_params(name: str, model: eqx.Module, filter_spec=eqx.is_inexact_array):
+    """Register numpyro params for an equinox module. This simply partitions the
+    parameters and static components, registers the parameters using numpyro param,
+    then recombines them."""
+    params, static = eqx.partition(model, filter_spec)
+    params = numpyro.param(name, params)
+    model = eqx.combine(params, static)
+    return model

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -70,7 +70,7 @@ class _VectorizedBijection:
     def __init__(self, bijection: Bijection):
         """
         Args:
-            bijection (Bijection): flowjax bijection to be wrapped.
+            bijection (AbstractBijection): flowjax bijection to be wrapped.
             domain (constraints.Constraint, optional): Numpyro constraint.
                 Defaults to constraints.real.
         """

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -22,7 +22,7 @@ except ImportError as e:
 from numpyro.distributions import constraints
 
 from flowjax.bijections import AbstractBijection
-from flowjax.distributions import Transformed
+from flowjax.distributions import AbstractTransformed
 from flowjax.utils import _get_ufunc_signature
 
 # TODO list:
@@ -79,7 +79,7 @@ class TransformedToNumpyro(numpyro.distributions.Distribution):
 
     def __init__(
         self,
-        dist: Transformed,
+        dist: AbstractTransformed,
         condition: ArrayLike | None = None,
         support: constraints.Constraint = constraints.real,
     ):

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -61,7 +61,8 @@ class _VectorizedBijection:
 
     def transform_and_log_det(self, x, condition=None):
         transform_and_log_det = self.vectorize(
-            self.bijection.transform_and_log_det, log_det=True,
+            self.bijection.transform_and_log_det,
+            log_det=True,
         )
         return transform_and_log_det(x, condition)
 
@@ -142,7 +143,9 @@ class TransformedToNumpyro(numpyro.distributions.Distribution):
 
 
 def register_params(
-    name: str, model: PyTree, filter_spec: Callable | PyTree = eqx.is_inexact_array,
+    name: str,
+    model: PyTree,
+    filter_spec: Callable | PyTree = eqx.is_inexact_array,
 ):
     """Register numpyro params for an arbitrary pytree.
 

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -33,7 +33,7 @@ from flowjax.utils import _get_ufunc_signature
 # to apply constraints lead to problems with reparameterisation?
 
 
-class VectorizedBijection(eqx.Module, strict=True):
+class VectorizedBijection(eqx.Module):
     "Wrap a flowjax bijection to support vectorization."
 
     def __init__(self, bijection: AbstractBijection):

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -18,7 +18,7 @@ try:
 except ImportError as e:
     e.add_note(
         "Note, in order to interface with numpyro, it must be installed. Please see "
-        "https://num.pyro.ai/en/latest/getting_started.html#installation"
+        "https://num.pyro.ai/en/latest/getting_started.html#installation",
     )
     raise
 
@@ -60,7 +60,7 @@ class _VectorizedBijection:
 
     def transform_and_log_det(self, x, condition=None):
         transform_and_log_det = self.vectorize(
-            self.bijection.transform_and_log_det, log_det=True
+            self.bijection.transform_and_log_det, log_det=True,
         )
         return transform_and_log_det(x, condition)
 
@@ -126,7 +126,7 @@ class TransformedToNumpyro(numpyro.distributions.Distribution):
         else:
             z = intermediates[0]
             _, log_det = _VectorizedBijection(
-                self.dist.bijection
+                self.dist.bijection,
             ).transform_and_log_det(z, self.condition)
             return self.dist.base_dist.log_prob(z, self._base_condition) - log_det
 
@@ -141,7 +141,7 @@ class TransformedToNumpyro(numpyro.distributions.Distribution):
 
 
 def register_params(
-    name: str, model: PyTree, filter_spec: Callable | PyTree = eqx.is_inexact_array
+    name: str, model: PyTree, filter_spec: Callable | PyTree = eqx.is_inexact_array,
 ):
     """Register numpyro params for an arbitrary pytree.
 

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -1,37 +1,7 @@
-"""
-Interfacing with numpyro
-==========================
+"""Utilities for interfacing with numpyro.
 
 Note these utilities require `numpyro <https://github.com/pyro-ppl/numpyro>`_ to be
-installed. Supporting complex inference approaches such as MCMC or variational inference
-with arbitrary probabilistic models is out of the scope of this package. However, we do
-provide an (experimental) wrapper class, :class:`TransformedToNumpyro`, which will wrap
-a flowjax :class:`~flowjax.distributions.Transformed` distribution, into a 
-`numpyro <https://github.com/pyro-ppl/numpyro>`_ distribution.
-This can be used for example to embed normalising flows into arbitrary
-probabilistic models. Here is a simple example
-
-    .. doctest::
-
-        >>> from numpyro.infer import MCMC, NUTS
-        >>> from flowjax.experimental.numpyro import TransformedToNumpyro
-        >>> from numpyro import sample
-        >>> from flowjax.distributions import Normal
-        >>> import jax.random as jr
-        >>> import numpy as np
-
-        >>> def numpyro_model(X, y):
-        ...     "Example regression model defined in terms of flowjax distributions"
-        ...     beta = sample("beta", TransformedToNumpyro(Normal(np.zeros(2))))
-        ...     sample("y", TransformedToNumpyro(Normal(X @ beta)), obs=y)
-
-        >>> X = np.random.randn(100, 2)
-        >>> beta_true = np.array([-1, 1])
-        >>> y = X @ beta_true + np.random.randn(100)
-        >>> mcmc = MCMC(NUTS(numpyro_model), num_warmup=10, num_samples=100)
-        >>> mcmc.run(jr.PRNGKey(0), X, y)
-
-
+installed.
 """
 
 from typing import Any, Callable
@@ -40,6 +10,8 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jax.typing import ArrayLike
+
+from flowjax.utils import arraylike_to_array
 
 try:
     import numpyro
@@ -52,8 +24,8 @@ except ImportError as e:
 
 from numpyro.distributions import constraints
 
-from flowjax.bijections import Bijection
-from flowjax.distributions import Transformed
+from flowjax.bijections import AbstractBijection
+from flowjax.distributions import AbstractTransformed
 from flowjax.utils import _get_ufunc_signature
 
 PyTree = Any
@@ -65,14 +37,14 @@ PyTree = Any
 
 
 class _VectorizedBijection:
-    "Wrap a flowjax bijection to support vectorization."
+    """Wrap a flowjax bijection to support vectorization."""
 
-    def __init__(self, bijection: Bijection):
-        """
+    def __init__(self, bijection: AbstractBijection):
+        """Initialize the vectorized bijection.
+
         Args:
             bijection (AbstractBijection): flowjax bijection to be wrapped.
-            domain (constraints.Constraint, optional): Numpyro constraint.
-                Defaults to constraints.real.
+            Defaults to constraints.real.
         """
         self.bijection = bijection
         self.shape = self.bijection.shape
@@ -106,24 +78,26 @@ class _VectorizedBijection:
 
 
 class TransformedToNumpyro(numpyro.distributions.Distribution):
-    """Convert a :class:`Transformed` flowjax distribution to a numpyro distribution. We
-    assume the support of the distribution is unbounded.
+    """Convert a :class:`Transformed` flowjax distribution to a numpyro distribution.
+
+    We assume the support of the distribution is unbounded.
     """
 
     def __init__(
         self,
-        dist: Transformed,
+        dist: AbstractTransformed,
         condition: ArrayLike | None = None,
     ):
-        """
+        """Initialize the numpyro distribution.
+
         Args:
-            dist (Transformed): The distribution
+            dist (AbstractTransformed): The distribution
             condition (ArrayLike | None, optional): Conditioning variables. Any
-                leading batch dimensions will be converted to a batch dimension in
-                the numpyro distribution. Defaults to None.
+            leading batch dimensions will be converted to a batch dimension in
+            the numpyro distribution. Defaults to None.
         """
-        condition = dist._argcheck_and_cast_condition(condition)
         if condition is not None:
+            condition = arraylike_to_array(condition, "condition")
             batch_shape = (
                 condition.shape[: -len(dist.cond_shape)] if dist.cond_ndim > 0 else ()
             )
@@ -136,14 +110,17 @@ class TransformedToNumpyro(numpyro.distributions.Distribution):
         super().__init__(batch_shape=batch_shape, event_shape=dist.shape)
 
     def sample(self, key, sample_shape=...):
+        """Sample the distribution."""
         return self.dist.sample(key, sample_shape, self.condition)
 
     def sample_with_intermediates(self, key, sample_shape=...):
-        z = self.dist.base_dist.sample(key, sample_shape, self.base_condition)
+        """Sample the distribution returning the base distribution sample."""
+        z = self.dist.base_dist.sample(key, sample_shape, self._base_condition)
         x = _VectorizedBijection(self.dist.bijection).transform(z, self.condition)
         return x, [z]
 
     def log_prob(self, value, intermediates=None):
+        """Compute the log probabilities."""
         if intermediates is None:
             return self.dist.log_prob(value, self.condition)
         else:
@@ -151,25 +128,26 @@ class TransformedToNumpyro(numpyro.distributions.Distribution):
             _, log_det = _VectorizedBijection(
                 self.dist.bijection
             ).transform_and_log_det(z, self.condition)
-            return self.dist.base_dist.log_prob(z, self.base_condition) - log_det
+            return self.dist.base_dist.log_prob(z, self._base_condition) - log_det
 
     @property
     def condition(self):
+        """condition, wrapped with stop gradient to avoid training."""
         return jax.lax.stop_gradient(self._condition)
 
     @property
-    def base_condition(self):
+    def _base_condition(self):
         return self.condition if self.dist.base_dist.cond_shape else None
 
 
 def register_params(
     name: str, model: PyTree, filter_spec: Callable | PyTree = eqx.is_inexact_array
 ):
-    """Register numpyro params for an arbitrary pytree (e.g. an equinox module,
-    flowjax distribution/bijection). This simply partitions the parameters and static
-    components, registers the parameters using numpyro.param, then recombines them.
-    This should be called from within an inference context, e.g. within a numpyro
-    model or guide function to have an effect.
+    """Register numpyro params for an arbitrary pytree.
+
+    This partitions the parameters and static components, registers the parameters using
+    numpyro.param, then recombines them. This should be called from within an inference
+    context to have an effect, e.g. within a numpyro model or guide function.
 
     Args:
         name (str): Name for the parameter set.

--- a/flowjax/flows.py
+++ b/flowjax/flows.py
@@ -10,6 +10,7 @@ import jax.nn as jnn
 import jax.numpy as jnp
 import jax.random as jr
 from equinox.nn import Linear
+from jax import Array
 from jax.nn.initializers import glorot_uniform
 
 from flowjax.bijections import (
@@ -43,7 +44,7 @@ class CouplingFlow(AbstractTransformed):
 
     def __init__(
         self,
-        key: jr.KeyArray,
+        key: Array,
         base_dist: AbstractDistribution,
         transformer: AbstractBijection,
         cond_dim: int | None = None,
@@ -56,7 +57,7 @@ class CouplingFlow(AbstractTransformed):
         """Initialize the coupling flow.
 
         Args:
-            key (jr.KeyArray): Jax PRNGKey.
+            key (Array): Jax PRNGKey.
             base_dist (AbstractDistribution): Base distribution.
             transformer (AbstractBijection): Bijection to be parameterised by
             conditioner.
@@ -115,7 +116,7 @@ class MaskedAutoregressiveFlow(AbstractTransformed):
 
     def __init__(
         self,
-        key: jr.KeyArray,
+        key: Array,
         base_dist: AbstractDistribution,
         transformer: AbstractBijection,
         cond_dim: int | None = None,
@@ -128,7 +129,7 @@ class MaskedAutoregressiveFlow(AbstractTransformed):
         """Initialize the masked autoregressive flow.
 
         Args:
-            key (jr.KeyArray): Random seed.
+            key (Array): Random seed.
             base_dist (AbstractDistribution): Base distribution.
             transformer (AbstractBijection): Bijection parameterised by autoregressive
                 network.
@@ -188,7 +189,7 @@ class BlockNeuralAutoregressiveFlow(AbstractTransformed):
 
     def __init__(
         self,
-        key: jr.KeyArray,
+        key: Array,
         base_dist: AbstractDistribution,
         cond_dim: int | None = None,
         nn_depth: int = 1,
@@ -200,7 +201,7 @@ class BlockNeuralAutoregressiveFlow(AbstractTransformed):
         """Initialize the block neural autoregressive flow.
 
         Args:
-            key (jr.KeyArray): Jax PRNGKey.
+            key (Array): Jax PRNGKey.
             base_dist (AbstractDistribution): Base distribution.
             cond_dim (int | None): Dimension of conditional variables.
             nn_depth (int): Number of hidden layers within the networks.
@@ -259,7 +260,7 @@ class PlanarFlow(AbstractTransformed):
 
     def __init__(
         self,
-        key: jr.KeyArray,
+        key: Array,
         base_dist: AbstractDistribution,
         cond_dim: int | None = None,
         flow_layers: int = 8,
@@ -269,7 +270,7 @@ class PlanarFlow(AbstractTransformed):
         """Initialize the planar flow.
 
         Args:
-            key (jr.KeyArray): Jax PRNGKey.
+            key (Array): Jax PRNGKey.
             base_dist (AbstractDistribution): Base distribution.
             cond_dim (int): Dimension of conditioning variables. Defaults to None.
             flow_layers (int): Number of flow layers. Defaults to 5.
@@ -316,7 +317,7 @@ class TriangularSplineFlow(AbstractTransformed):
 
     def __init__(
         self,
-        key: jr.KeyArray,
+        key: Array,
         base_dist: AbstractDistribution,
         cond_dim: int | None = None,
         flow_layers: int = 8,
@@ -328,7 +329,7 @@ class TriangularSplineFlow(AbstractTransformed):
         """Initialize the triangular spline flow.
 
         Args:
-            key (jr.KeyArray): Jax random seed.
+            key (Array): Jax random seed.
             base_dist (AbstractDistribution): Base distribution of the flow.
             cond_dim (int | None): The number of conditioning features.
                 Defaults to None.
@@ -390,7 +391,7 @@ class TriangularSplineFlow(AbstractTransformed):
         self.bijection = bijection
 
 
-def _add_default_permute(bijection: AbstractBijection, dim: int, key: jr.KeyArray):
+def _add_default_permute(bijection: AbstractBijection, dim: int, key: Array):
     if dim == 1:
         return bijection
     if dim == 2:

--- a/flowjax/flows.py
+++ b/flowjax/flows.py
@@ -59,8 +59,8 @@ class CouplingFlow(AbstractTransformed):
         """
         Args:
             key (jr.KeyArray): Jax PRNGKey.
-            base_dist (Distribution): Base distribution.
-            transformer (Bijection): Bijection to be parameterised by conditioner.
+            base_dist (AbstractDistribution): Base distribution.
+            transformer (AbstractBijection): Bijection to be parameterised by conditioner.
             cond_dim (int): Dimension of conditioning variables. Defaults to None.
             flow_layers (int): Number of coupling layers. Defaults to 5.
             nn_width (int): Conditioner hidden layer size. Defaults to 40.
@@ -135,8 +135,8 @@ class MaskedAutoregressiveFlow(AbstractTransformed):
         """
         Args:
             key (jr.KeyArray): Random seed.
-            base_dist (Distribution): Base distribution.
-            transformer (Bijection): Bijection parameterised by autoregressive network.
+            base_dist (AbstractDistribution): Base distribution.
+            transformer (AbstractBijection): Bijection parameterised by autoregressive network.
             cond_dim (int): _description_. Defaults to 0.
             flow_layers (int): Number of flow layers. Defaults to 5.
             nn_width (int): Number of hidden layers in neural network. Defaults to 40.
@@ -211,7 +211,7 @@ class BlockNeuralAutoregressiveFlow(AbstractTransformed):
         """
         Args:
             key (jr.KeyArray): Jax PRNGKey.
-            base_dist (Distribution): Base distribution.
+            base_dist (AbstractDistribution): Base distribution.
             cond_dim (int | None): Dimension of conditional variables.
             nn_depth (int): Number of hidden layers within the networks.
                 Defaults to 1.
@@ -290,7 +290,7 @@ class TriangularSplineFlow(AbstractTransformed):
         """
         Args:
             key (jr.KeyArray): Jax random seed.
-            base_dist (Distribution): Base distribution of the flow.
+            base_dist (AbstractDistribution): Base distribution of the flow.
             cond_dim (int | None): The number of conditioning features.
                 Defaults to None.
             flow_layers (int): Number of flow layers. Defaults to 8.
@@ -378,7 +378,7 @@ class PlanarFlow(AbstractTransformed):
         """
         Args:
             key (jr.KeyArray): Jax PRNGKey.
-            base_dist (Distribution): Base distribution.
+            base_dist (AbstractDistribution): Base distribution.
             cond_dim (int): Dimension of conditioning variables. Defaults to None.
             flow_layers (int): Number of flow layers. Defaults to 5.
             invert: (bool): Whether to invert the bijection. Broadly, True will

--- a/flowjax/flows.py
+++ b/flowjax/flows.py
@@ -3,7 +3,7 @@
 # we generally opt to use `Scan`, which avoids excessive compilation
 # when the flow layers share the same structure.
 
-from typing import Callable
+from collections.abc import Callable
 
 import equinox as eqx
 import jax.nn as jnn
@@ -90,8 +90,7 @@ class CouplingFlow(AbstractTransformed):
                 nn_depth=nn_depth,
                 nn_activation=nn_activation,
             )
-            bijection = _add_default_permute(bijection, dim, perm_key)
-            return bijection
+            return _add_default_permute(bijection, dim, perm_key)
 
         keys = jr.split(key, flow_layers)
         layers = eqx.filter_vmap(make_layer)(keys)
@@ -167,8 +166,7 @@ class MaskedAutoregressiveFlow(AbstractTransformed):
                 nn_depth=nn_depth,
                 nn_activation=nn_activation,
             )
-            bijection = _add_default_permute(bijection, dim, perm_key)
-            return bijection
+            return _add_default_permute(bijection, dim, perm_key)
 
         keys = jr.split(key, flow_layers)
         layers = eqx.filter_vmap(make_layer)(keys)
@@ -250,8 +248,7 @@ class BlockNeuralAutoregressiveFlow(AbstractTransformed):
                 block_dim=nn_block_dim,
                 activation=activation,
             )
-            bijection = _add_default_permute(bijection, dim, perm_key)
-            return bijection
+            return _add_default_permute(bijection, dim, perm_key)
 
         keys = jr.split(key, flow_layers)
         layers = eqx.filter_vmap(make_layer)(keys)
@@ -346,8 +343,7 @@ class TriangularSplineFlow(AbstractTransformed):
                 bijections.append(linear_condition)
 
             bijection = Chain(bijections)
-            bijection = _add_default_permute(bijection, dim, perm_key)
-            return bijection
+            return _add_default_permute(bijection, dim, perm_key)
 
         keys = jr.split(key, flow_layers)
         layers = eqx.filter_vmap(make_layer)(keys)
@@ -408,8 +404,7 @@ class PlanarFlow(AbstractTransformed):
         def make_layer(key):  # Planar layer + permutation
             bij_key, perm_key = jr.split(key)
             bijection = Planar(bij_key, dim, cond_dim, **mlp_kwargs)
-            bijection = _add_default_permute(bijection, dim, perm_key)
-            return bijection
+            return _add_default_permute(bijection, dim, perm_key)
 
         keys = jr.split(key, flow_layers)
         layers = eqx.filter_vmap(make_layer)(keys)
@@ -428,9 +423,9 @@ def _add_default_permute(bijection: AbstractBijection, dim: int, key: jr.KeyArra
         return bijection
     if dim == 2:
         return Chain([bijection, Flip((dim,))]).merge_chains()
-    else:
-        perm = Permute(jr.permutation(key, jnp.arange(dim)))
-        return Chain([bijection, perm]).merge_chains()
+
+    perm = Permute(jr.permutation(key, jnp.arange(dim)))
+    return Chain([bijection, perm]).merge_chains()
 
 
 def _get_default_permute_name(dim):

--- a/flowjax/flows.py
+++ b/flowjax/flows.py
@@ -324,7 +324,7 @@ class TriangularSplineFlow(AbstractTransformed):
             weights = init(lt_key, (dim, dim))
             lt_weights = weights.at[jnp.diag_indices(dim)].set(1)
             lower_tri = TriangularAffine(
-                jnp.zeros(dim), lt_weights, weight_normalisation=True
+                jnp.zeros(dim), lt_weights, weight_normalisation=True,
             )
 
             bijections = [

--- a/flowjax/masks.py
+++ b/flowjax/masks.py
@@ -39,6 +39,6 @@ def block_tril_mask(block_shape: tuple, n_blocks: int):
     mask = jnp.zeros((block_shape[0] * n_blocks, block_shape[1] * n_blocks), jnp.int32)
     for i in range(n_blocks):
         mask = mask.at[
-            (i + 1) * block_shape[0] :, i * block_shape[1] : (i + 1) * block_shape[1]
+            (i + 1) * block_shape[0] :, i * block_shape[1] : (i + 1) * block_shape[1],
         ].set(1)
     return mask

--- a/flowjax/masks.py
+++ b/flowjax/masks.py
@@ -29,6 +29,7 @@ def rank_based_mask(in_ranks: Array, out_ranks: Array, eq: bool = False):
     op = operator.ge if eq else operator.gt
     return op(out_ranks[:, None], in_ranks).astype(jnp.int32)
 
+
 def block_diag_mask(block_shape: tuple, n_blocks: int):
     """Block diagonal mask."""
     return block_diag(*jnp.ones((n_blocks, *block_shape), jnp.int32))
@@ -39,6 +40,7 @@ def block_tril_mask(block_shape: tuple, n_blocks: int):
     mask = jnp.zeros((block_shape[0] * n_blocks, block_shape[1] * n_blocks), jnp.int32)
     for i in range(n_blocks):
         mask = mask.at[
-            (i + 1) * block_shape[0] :, i * block_shape[1] : (i + 1) * block_shape[1],
+            (i + 1) * block_shape[0] :,
+            i * block_shape[1] : (i + 1) * block_shape[1],
         ].set(1)
     return mask

--- a/flowjax/masks.py
+++ b/flowjax/masks.py
@@ -1,6 +1,8 @@
-"""
-Various masks, generally used in flows to enforce e.g. a dependency structure
-that leads to invertibility and efficient Jacobian determinant calculations.
+"""Masks used in flows.
+
+Masks are generally used in flows to mask out some weights, in order to enforce a
+dependency structure that ensures invertibility and efficient Jacobian determinant
+calculations.
 """
 
 import jax.numpy as jnp

--- a/flowjax/masks.py
+++ b/flowjax/masks.py
@@ -5,6 +5,8 @@ dependency structure that ensures invertibility and efficient Jacobian determina
 calculations.
 """
 
+import operator
+
 import jax.numpy as jnp
 from jax import Array
 from jax.scipy.linalg import block_diag
@@ -21,13 +23,11 @@ def rank_based_mask(in_ranks: Array, out_ranks: Array, eq: bool = False):
     Returns:
         Array: Mask with shape `(len(out_ranks), len(in_ranks))`
     """
-    assert (in_ranks.ndim) == 1 and (out_ranks.ndim == 1)
-    if eq:
-        mask = out_ranks[:, None] >= in_ranks
-    else:
-        mask = out_ranks[:, None] > in_ranks
-    return mask.astype(jnp.int32)
-
+    for ranks in (in_ranks, out_ranks):
+        if ranks.ndim != 1:
+            raise ValueError(f"Expected ranks.ndim==1, got {ranks.ndim}")
+    op = operator.ge if eq else operator.gt
+    return op(out_ranks[:, None], in_ranks).astype(jnp.int32)
 
 def block_diag_mask(block_shape: tuple, n_blocks: int):
     """Block diagonal mask."""

--- a/flowjax/nn/__init__.py
+++ b/flowjax/nn/__init__.py
@@ -1,6 +1,4 @@
-"""nn package contains neural network architectures of use for flows (invertible
-neural networks).
-"""
+"""Contains invertible neural network architectures of use for constructing flows."""
 
 from .block_autoregressive import BlockAutoregressiveLinear
 from .masked_autoregressive import AutoregressiveMLP, MaskedLinear

--- a/flowjax/nn/block_autoregressive.py
+++ b/flowjax/nn/block_autoregressive.py
@@ -1,5 +1,5 @@
 """Block autoregressive neural network components."""
-from typing import Callable
+from collections.abc import Callable
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -66,7 +66,7 @@ class BlockAutoregressiveLinear(eqx.Module):
 
         self.b_diag_mask_idxs = jnp.where(
             self.b_diag_mask, size=block_shape[0] * block_shape[1] * n_blocks,
-        )  # type: ignore
+        )
 
         in_features, out_features = (
             block_shape[1] * n_blocks + cond_dim,

--- a/flowjax/nn/block_autoregressive.py
+++ b/flowjax/nn/block_autoregressive.py
@@ -65,7 +65,8 @@ class BlockAutoregressiveLinear(eqx.Module):
         )
 
         self.b_diag_mask_idxs = jnp.where(
-            self.b_diag_mask, size=block_shape[0] * block_shape[1] * n_blocks,
+            self.b_diag_mask,
+            size=block_shape[0] * block_shape[1] * n_blocks,
         )
 
         in_features, out_features = (
@@ -108,6 +109,7 @@ class BlockAutoregressiveLinear(eqx.Module):
             x = jnp.concatenate((x, condition))
         y = weights @ x + self.bias
         jac_3d = weights[self.b_diag_mask_idxs].reshape(
-            self.n_blocks, *self.block_shape,
+            self.n_blocks,
+            *self.block_shape,
         )
         return y, jnp.log(jac_3d)

--- a/flowjax/nn/block_autoregressive.py
+++ b/flowjax/nn/block_autoregressive.py
@@ -12,6 +12,7 @@ from flowjax.masks import block_diag_mask, block_tril_mask
 
 class BlockAutoregressiveLinear(eqx.Module):
     """Block autoregressive neural network layer (https://arxiv.org/abs/1904.04676).
+
     Conditioning variables are incorporated by appending columns (one for each
     conditioning variable) to the right of the block diagonal weight matrix.
     """
@@ -36,9 +37,10 @@ class BlockAutoregressiveLinear(eqx.Module):
         cond_dim: int | None = None,
         init: Callable | None = None,
     ):
-        """
+        """Initialize the block autoregressive linear layer.
+
         Args:
-            key KeyArray: Random key
+            key (KeyArray): Random key
             n_blocks (int): Number of diagonal blocks (dimension of original input).
             block_shape (tuple): The shape of the (unconstrained) blocks.
             cond_dim (int | None): Number of additional conditioning variables.
@@ -96,8 +98,10 @@ class BlockAutoregressiveLinear(eqx.Module):
         return jnp.exp(self.weight_log_scale) * weights / weight_norms
 
     def __call__(self, x, condition=None):
-        """returns output y, and components of weight matrix needed log_det component
-        (n_blocks, block_shape[0], block_shape[1]).
+        """Returns output y, and components of weight matrix needed log_det component.
+
+        The components of the weight matrix have shape
+        ``(n_blocks, block_shape[0], block_shape[1])``.
         """
         weights = self.get_normalised_weights()
         if condition is not None:

--- a/flowjax/nn/block_autoregressive.py
+++ b/flowjax/nn/block_autoregressive.py
@@ -57,15 +57,15 @@ class BlockAutoregressiveLinear(eqx.Module):
         cond_size = (block_shape[0] * n_blocks, cond_dim)
 
         self.b_diag_mask = jnp.column_stack(
-            (block_diag_mask(block_shape, n_blocks), jnp.zeros(cond_size, jnp.int32))
+            (block_diag_mask(block_shape, n_blocks), jnp.zeros(cond_size, jnp.int32)),
         )
 
         self.b_tril_mask = jnp.column_stack(
-            (block_tril_mask(block_shape, n_blocks), jnp.ones(cond_size, jnp.int32))
+            (block_tril_mask(block_shape, n_blocks), jnp.ones(cond_size, jnp.int32)),
         )
 
         self.b_diag_mask_idxs = jnp.where(
-            self.b_diag_mask, size=block_shape[0] * block_shape[1] * n_blocks
+            self.b_diag_mask, size=block_shape[0] * block_shape[1] * n_blocks,
         )  # type: ignore
 
         in_features, out_features = (
@@ -108,6 +108,6 @@ class BlockAutoregressiveLinear(eqx.Module):
             x = jnp.concatenate((x, condition))
         y = weights @ x + self.bias
         jac_3d = weights[self.b_diag_mask_idxs].reshape(
-            self.n_blocks, *self.block_shape
+            self.n_blocks, *self.block_shape,
         )
         return y, jnp.log(jac_3d)

--- a/flowjax/nn/masked_autoregressive.py
+++ b/flowjax/nn/masked_autoregressive.py
@@ -23,7 +23,7 @@ class MaskedLinear(Module):
     mask: Array
 
     def __init__(self, mask: ArrayLike, use_bias: bool = True, *, key: KeyArray):
-        """
+        """Initialize the masked linear layer.
 
         Args:
             mask (ArrayLike): Mask with shape (out_features, in_features).
@@ -35,7 +35,7 @@ class MaskedLinear(Module):
         self.mask = mask
 
     def __call__(self, x: ArrayLike):
-        """Run the masked linear layer
+        """Run the masked linear layer.
 
         Args:
             x (ArrayLike): Array with shape ``(mask.shape[1], )``
@@ -48,8 +48,10 @@ class MaskedLinear(Module):
 
 
 class AutoregressiveMLP(Module):
-    """An autoregressive multilayer perceptron, similar to ``equinox.nn.composed.MLP``.
-    Connections will only exist where in_ranks < out_ranks.
+    """An autoregressive multilayer perceptron.
+
+    Similar to ``equinox.nn.composed.MLP``, however, connections will only exist between
+    nodes where in_ranks < out_ranks.
     """
 
     in_size: int
@@ -74,7 +76,8 @@ class AutoregressiveMLP(Module):
         *,
         key,
     ) -> None:
-        """
+        """Initialize the autoregressive multilayer perceptron.
+
         Args:
             in_ranks (ArrayLike): Ranks of the inputs.
             hidden_ranks (ArrayLike): Ranks of the hidden layer(s).
@@ -115,6 +118,7 @@ class AutoregressiveMLP(Module):
 
     def __call__(self, x: Array):
         """Forward pass.
+
         Args:
             x: A JAX array with shape (in_size,).
         """

--- a/flowjax/nn/masked_autoregressive.py
+++ b/flowjax/nn/masked_autoregressive.py
@@ -99,7 +99,7 @@ class AutoregressiveMLP(Module):
             masks.extend(
                 rank_based_mask(hidden_ranks, hidden_ranks, eq=True)
                 for _ in range(depth - 1)
-                )
+            )
             masks.append(rank_based_mask(hidden_ranks, out_ranks, eq=False))
 
         keys = random.split(key, len(masks))
@@ -128,4 +128,4 @@ class AutoregressiveMLP(Module):
             x = layer(x)
             x = self.activation(x)
         x = self.layers[-1](x)
-        return  self.final_activation(x)
+        return self.final_activation(x)

--- a/flowjax/nn/masked_autoregressive.py
+++ b/flowjax/nn/masked_autoregressive.py
@@ -88,9 +88,9 @@ class AutoregressiveMLP(Module):
                 _identity.
             key (KeyArray): Jax PRNGKey.
         """
-        in_ranks, hidden_ranks, out_ranks = [
+        in_ranks, hidden_ranks, out_ranks = (
             jnp.asarray(a) for a in [in_ranks, hidden_ranks, out_ranks]
-        ]
+        )
         masks = []
         if depth == 0:
             masks.append(rank_based_mask(in_ranks, out_ranks, eq=False))

--- a/flowjax/tasks.py
+++ b/flowjax/tasks.py
@@ -4,12 +4,13 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.random as jr
+from jax import Array
 from jax.typing import ArrayLike
 
 from flowjax.distributions import Uniform
 
 
-def two_moons(key: jr.KeyArray, n_samples, noise_std=0.2):
+def two_moons(key: Array, n_samples, noise_std=0.2):
     """Two moon distribution."""
     angle_key, noise_key = jr.split(key)
     angle = jr.uniform(angle_key, (n_samples,)) * 2 * jnp.pi
@@ -38,7 +39,7 @@ class GaussianMixtureSimulator:
         self.prior = Uniform(-jnp.full(dim, prior_bound), jnp.full(dim, prior_bound))
 
     @eqx.filter_jit
-    def simulator(self, key: jr.KeyArray, theta: ArrayLike):
+    def simulator(self, key: Array, theta: ArrayLike):
         """Carry out simulations."""
         theta = jnp.atleast_2d(jnp.asarray(theta))
         key, subkey = jr.split(key)
@@ -50,7 +51,7 @@ class GaussianMixtureSimulator:
 
     def sample_reference_posterior(
         self,
-        key: jr.KeyArray,
+        key: Array,
         observation: ArrayLike,
         num_samples: int,
     ):

--- a/flowjax/tasks.py
+++ b/flowjax/tasks.py
@@ -70,7 +70,8 @@ class GaussianMixtureSimulator:
             key, subkey = jr.split(key)
 
             candidates = jax.jit(jax.vmap(self.simulator, in_axes=[0, None]))(
-                jr.split(subkey, num_samples), observation,
+                jr.split(subkey, num_samples),
+                observation,
             )
             in_prior_support = self.prior.log_prob(candidates) != -jnp.inf
             sample_counter += in_prior_support.sum()

--- a/flowjax/tasks.py
+++ b/flowjax/tasks.py
@@ -9,7 +9,7 @@ from jax.typing import ArrayLike
 from flowjax.distributions import Uniform
 
 
-def two_moons(key, n_samples, noise_std=0.2):
+def two_moons(key: jr.KeyArray, n_samples, noise_std=0.2):
     """Two moon distribution."""
     angle_key, noise_key = jr.split(key)
     angle = jr.uniform(angle_key, (n_samples,)) * 2 * jnp.pi
@@ -70,7 +70,7 @@ class GaussianMixtureSimulator:
             key, subkey = jr.split(key)
 
             candidates = jax.jit(jax.vmap(self.simulator, in_axes=[0, None]))(
-                jr.split(subkey, num_samples), observation
+                jr.split(subkey, num_samples), observation,
             )
             in_prior_support = self.prior.log_prob(candidates) != -jnp.inf
             sample_counter += in_prior_support.sum()

--- a/flowjax/train/__init__.py
+++ b/flowjax/train/__init__.py
@@ -1,6 +1,4 @@
-"""The train sub-package contains basic functions for training flows, to
-samples from a target distribution, or by using variational inference.
-"""
+"""Utilities for training flows, fitting to samples or ysing variational inference."""
 
 from .data_fit import fit_to_data
 from .variational_fit import fit_to_variational_target

--- a/flowjax/train/data_fit.py
+++ b/flowjax/train/data_fit.py
@@ -8,7 +8,7 @@ import optax
 from jax.typing import ArrayLike
 from tqdm import tqdm
 
-from flowjax.distributions import Distribution
+from flowjax.distributions import AbstractDistribution
 from flowjax.train.losses import MaximumLikelihoodLoss
 from flowjax.train.train_utils import (
     count_fruitless,
@@ -22,7 +22,7 @@ PyTree = Any
 
 def fit_to_data(
     key: jr.KeyArray,
-    dist: Distribution,
+    dist: AbstractDistribution,
     x: ArrayLike,
     condition: ArrayLike = None,
     loss_fn: Callable | None = None,

--- a/flowjax/train/data_fit.py
+++ b/flowjax/train/data_fit.py
@@ -6,6 +6,7 @@ import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import optax
+from jax import Array
 from jax.typing import ArrayLike
 from tqdm import tqdm
 
@@ -22,7 +23,7 @@ PyTree = Any
 
 
 def fit_to_data(
-    key: jr.KeyArray,
+    key: Array,
     dist: AbstractDistribution,
     x: ArrayLike,
     condition: ArrayLike = None,

--- a/flowjax/train/data_fit.py
+++ b/flowjax/train/data_fit.py
@@ -40,7 +40,7 @@ def fit_to_data(
 
     Args:
         key (KeyArray): Jax random seed.
-        dist (Distribution): Distribution object.
+        dist (AbstractDistribution): Distribution object.
         x (ArrayLike): Samples from target distribution.
         condition (ArrayLike | None): Conditioning variables. Defaults to None.
         loss_fn (Callable | None): Loss function. Defaults to MaximumLikelihoodLoss.

--- a/flowjax/train/data_fit.py
+++ b/flowjax/train/data_fit.py
@@ -1,5 +1,6 @@
 """Function to fit flows to samples from a distribution."""
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import equinox as eqx
 import jax.numpy as jnp

--- a/flowjax/train/data_fit.py
+++ b/flowjax/train/data_fit.py
@@ -35,8 +35,11 @@ def fit_to_data(
     filter_spec: Callable | PyTree = eqx.is_inexact_array,
     show_progress: bool = True,
 ):
-    """Train a distribution (e.g. a flow) to samples from the target distribution p(x)
-    or p(x|condition). Note that the last batch in each epoch is dropped if truncated.
+    r"""Train a distribution (e.g. a flow) to samples from the target distribution.
+
+    The distribution can be unconditional :math:`p(x)` or conditional
+    :math:`p(x|\text{condition})`. Note that the last batch in each epoch is dropped
+    if truncated.
 
     Args:
         key (KeyArray): Jax random seed.
@@ -88,7 +91,6 @@ def fit_to_data(
         # Train epoch
         batch_losses = []
         for batch in zip(*get_batches(train_data, batch_size), strict=True):
-            key, subkey = jr.split(key)
             params, opt_state, loss_i = step(
                 optimizer, opt_state, loss_fn, params, static, *batch
             )

--- a/flowjax/train/data_fit.py
+++ b/flowjax/train/data_fit.py
@@ -92,7 +92,7 @@ def fit_to_data(
         batch_losses = []
         for batch in zip(*get_batches(train_data, batch_size), strict=True):
             params, opt_state, loss_i = step(
-                optimizer, opt_state, loss_fn, params, static, *batch
+                optimizer, opt_state, loss_fn, params, static, *batch,
             )
             batch_losses.append(loss_i)
         losses["train"].append(sum(batch_losses) / len(batch_losses))

--- a/flowjax/train/data_fit.py
+++ b/flowjax/train/data_fit.py
@@ -93,7 +93,12 @@ def fit_to_data(
         batch_losses = []
         for batch in zip(*get_batches(train_data, batch_size), strict=True):
             params, opt_state, loss_i = step(
-                optimizer, opt_state, loss_fn, params, static, *batch,
+                optimizer,
+                opt_state,
+                loss_fn,
+                params,
+                static,
+                *batch,
             )
             batch_losses.append(loss_i)
         losses["train"].append(sum(batch_losses) / len(batch_losses))

--- a/flowjax/train/losses.py
+++ b/flowjax/train/losses.py
@@ -78,7 +78,8 @@ class ContrastiveLoss:
         contrastive = self._get_contrastive(x)
         joint_log_odds = dist.log_prob(x, condition) - self.prior.log_prob(x)
         contrastive_log_odds = dist.log_prob(
-            contrastive, condition,
+            contrastive,
+            condition,
         ) - self.prior.log_prob(contrastive)
         contrastive_log_odds = jnp.clip(contrastive_log_odds, -5)  # Clip for stability
         return -(joint_log_odds - logsumexp(contrastive_log_odds, axis=0)).mean()

--- a/flowjax/train/losses.py
+++ b/flowjax/train/losses.py
@@ -3,7 +3,7 @@
 The loss functions are callables, with the first two arguments being the partitioned
 distribution (see equinox.partition).
 """
-from typing import Callable
+from collections.abc import Callable
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -92,8 +92,7 @@ class ContrastiveLoss:
         # Rolling window over theta batch to create contrastive samples.
         idx = jnp.arange(len(theta))[:, None] + jnp.arange(self.n_contrastive)[None, :]
         contrastive = jnp.roll(theta[idx], -1, axis=0)  # Ensure mismatch with condition
-        contrastive = jnp.swapaxes(contrastive, 0, 1)  # (contrastive, batch_size, dim)
-        return contrastive
+        return jnp.swapaxes(contrastive, 0, 1)  # (contrastive, batch_size, dim)
 
 
 class ElboLoss:

--- a/flowjax/train/losses.py
+++ b/flowjax/train/losses.py
@@ -1,6 +1,8 @@
-"""Common loss functions for training normalizing flows. The loss functions are
-callables, with the first two arguments being the partitioned distribution (see
-equinox.partition)."""
+"""Common loss functions for training normalizing flows.
+
+The loss functions are callables, with the first two arguments being the partitioned
+distribution (see equinox.partition).
+"""
 from typing import Callable
 
 import equinox as eqx
@@ -15,8 +17,9 @@ from flowjax.distributions import AbstractDistribution
 
 
 class MaximumLikelihoodLoss:
-    """Loss for fitting a flow with maximum likelihood (negative log likelihood). Can
-    be used to learn either conditional or unconditional distributions.
+    """Loss for fitting a flow with maximum likelihood (negative log likelihood).
+
+    This loss can be used to learn either conditional or unconditional distributions.
     """
 
     @eqx.filter_jit
@@ -27,12 +30,14 @@ class MaximumLikelihoodLoss:
         x: Array,
         condition: Array | None = None,
     ):
+        """Compute the loss."""
         dist = eqx.combine(static, params)
         return -dist.log_prob(x, condition).mean()
 
 
 class ContrastiveLoss:
     r"""Loss function for use in a sequential neural posterior estimation algorithm.
+
     Learns a posterior ``p(x|condition)``. Contrastive samples for each ``x`` are
     generated from other x samples in the batch.
 
@@ -49,9 +54,11 @@ class ContrastiveLoss:
     """
 
     def __init__(self, prior: AbstractDistribution, n_contrastive: int):
-        """
+        """Initialize the loss function.
+
         Args:
-            prior (AbstractDistribution): The prior distribution over x (the target variable).
+            prior (AbstractDistribution): The prior distribution over x (the target
+                variable).
             n_contrastive (int): The number of contrastive samples/atoms to use when
                 computing the loss.
         """
@@ -66,6 +73,7 @@ class ContrastiveLoss:
         x: Array,
         condition: Array | None = None,
     ):
+        """Compute the loss."""
         dist = eqx.combine(params, static)
         contrastive = self._get_contrastive(x)
         joint_log_odds = dist.log_prob(x, condition) - self.prior.log_prob(x)
@@ -101,7 +109,8 @@ class ElboLoss:
         num_samples: int,
         stick_the_landing: bool = False,
     ):
-        """
+        """Initialize the ELBO loss.
+
         Args:
             num_samples (int): Number of samples to use in the ELBO approximation.
             target (Callable[[ArrayLike], Array]): The target, i.e. log posterior
@@ -126,6 +135,13 @@ class ElboLoss:
         static: AbstractDistribution,
         key: jr.KeyArray,
     ):
+        """Compute the ELBO loss.
+
+        Args:
+            params (AbstractDistribution): The trainable parameters of the model.
+            static (AbstractDistribution): The static components of the model.
+            key (jr.KeyArray): Jax random seed.
+        """
         dist = eqx.combine(params, static)
 
         if self.stick_the_landing:

--- a/flowjax/train/losses.py
+++ b/flowjax/train/losses.py
@@ -51,7 +51,7 @@ class ContrastiveLoss:
     def __init__(self, prior: AbstractDistribution, n_contrastive: int):
         """
         Args:
-            prior (Distribution): The prior distribution over x (the target variable).
+            prior (AbstractDistribution): The prior distribution over x (the target variable).
             n_contrastive (int): The number of contrastive samples/atoms to use when
                 computing the loss.
         """

--- a/flowjax/train/losses.py
+++ b/flowjax/train/losses.py
@@ -78,7 +78,7 @@ class ContrastiveLoss:
         contrastive = self._get_contrastive(x)
         joint_log_odds = dist.log_prob(x, condition) - self.prior.log_prob(x)
         contrastive_log_odds = dist.log_prob(
-            contrastive, condition
+            contrastive, condition,
         ) - self.prior.log_prob(contrastive)
         contrastive_log_odds = jnp.clip(contrastive_log_odds, -5)  # Clip for stability
         return -(joint_log_odds - logsumexp(contrastive_log_odds, axis=0)).mean()
@@ -87,7 +87,7 @@ class ContrastiveLoss:
         if theta.shape[0] <= self.n_contrastive:
             raise ValueError(
                 f"Number of contrastive samples {self.n_contrastive} must be less than "
-                f"the size of theta {theta.shape}."
+                f"the size of theta {theta.shape}.",
             )
         # Rolling window over theta batch to create contrastive samples.
         idx = jnp.arange(len(theta))[:, None] + jnp.arange(self.n_contrastive)[None, :]

--- a/flowjax/train/losses.py
+++ b/flowjax/train/losses.py
@@ -7,7 +7,6 @@ from collections.abc import Callable
 
 import equinox as eqx
 import jax.numpy as jnp
-import jax.random as jr
 from jax import Array, vmap
 from jax.lax import stop_gradient
 from jax.scipy.special import logsumexp
@@ -133,14 +132,14 @@ class ElboLoss:
         self,
         params: AbstractDistribution,
         static: AbstractDistribution,
-        key: jr.KeyArray,
+        key: Array,
     ):
         """Compute the ELBO loss.
 
         Args:
             params (AbstractDistribution): The trainable parameters of the model.
             static (AbstractDistribution): The static components of the model.
-            key (jr.KeyArray): Jax random seed.
+            key (Array): Jax random seed.
         """
         dist = eqx.combine(params, static)
 

--- a/flowjax/train/losses.py
+++ b/flowjax/train/losses.py
@@ -11,7 +11,7 @@ from jax.lax import stop_gradient
 from jax.scipy.special import logsumexp
 from jax.typing import ArrayLike
 
-from flowjax.distributions import Distribution
+from flowjax.distributions import AbstractDistribution
 
 
 class MaximumLikelihoodLoss:
@@ -22,8 +22,8 @@ class MaximumLikelihoodLoss:
     @eqx.filter_jit
     def __call__(
         self,
-        static: Distribution,
-        params: Distribution,
+        static: AbstractDistribution,
+        params: AbstractDistribution,
         x: Array,
         condition: Array | None = None,
     ):
@@ -48,7 +48,7 @@ class ContrastiveLoss:
 
     """
 
-    def __init__(self, prior: Distribution, n_contrastive: int):
+    def __init__(self, prior: AbstractDistribution, n_contrastive: int):
         """
         Args:
             prior (Distribution): The prior distribution over x (the target variable).
@@ -61,8 +61,8 @@ class ContrastiveLoss:
     @eqx.filter_jit
     def __call__(
         self,
-        static: Distribution,
-        params: Distribution,
+        static: AbstractDistribution,
+        params: AbstractDistribution,
         x: Array,
         condition: Array | None = None,
     ):
@@ -120,7 +120,12 @@ class ElboLoss:
         self.stick_the_landing = stick_the_landing
 
     @eqx.filter_jit
-    def __call__(self, params: Distribution, static: Distribution, key: jr.KeyArray):
+    def __call__(
+        self,
+        params: AbstractDistribution,
+        static: AbstractDistribution,
+        key: jr.KeyArray,
+    ):
         dist = eqx.combine(params, static)
 
         if self.stick_the_landing:

--- a/flowjax/train/train_utils.py
+++ b/flowjax/train/train_utils.py
@@ -30,7 +30,7 @@ def step(
     return params, opt_state, loss_val
 
 
-def train_val_split(key: jr.KeyArray, arrays: Sequence[Array], val_prop: float = 0.1):
+def train_val_split(key: Array, arrays: Sequence[Array], val_prop: float = 0.1):
     """Random train validation split for a sequence of arrays.
 
     Args:

--- a/flowjax/train/train_utils.py
+++ b/flowjax/train/train_utils.py
@@ -34,7 +34,7 @@ def train_val_split(key: jr.KeyArray, arrays: Sequence[Array], val_prop: float =
 
     Args:
         key (KeyArray): Jax random key.
-        arrays Sequence[Array]: Sequence of arrays, with matching size on axis 0.
+        arrays (Sequence[Array]): Sequence of arrays, with matching size on axis 0.
         val_prop (float): Proportion of data to use for validation. Defaults to 0.1.
 
     Returns:
@@ -56,9 +56,10 @@ def train_val_split(key: jr.KeyArray, arrays: Sequence[Array], val_prop: float =
 
 @partial(jit, static_argnums=1)
 def get_batches(arrays: Sequence[Array], batch_size: int):
-    """Reshape a sequence of arrays to have an additional dimension for the batches,
-    i.e. transforming shape ``(data_len, *rest)`` to ``(num_batches, batch_size,
-    *rest)``.
+    """Reshape a sequence of arrays to have an additional dimension for the batches.
+
+    Specifically, this will transform an array with shape ``(data_len, *rest)`` to
+    ``(num_batches, batch_size, *rest)``.
 
     Considerations:
         - The values in the last batch are dropped if truncated, i.e. if
@@ -78,7 +79,7 @@ def get_batches(arrays: Sequence[Array], batch_size: int):
 
 
 def _add_batch(arr, batch_size):
-    "Adds a leading dimension for batches, dropping the last batch if truncated."
+    """Adds a leading dimension for batches, dropping the last batch if truncated."""
     batch_size = min(batch_size, arr.shape[0])
     n_batches = arr.shape[0] // batch_size
     arr = arr[: n_batches * batch_size].reshape(n_batches, batch_size, *arr.shape[1:])
@@ -86,8 +87,7 @@ def _add_batch(arr, batch_size):
 
 
 def count_fruitless(losses: list[float]) -> int:
-    """Given a list of losses from each epoch, count the number of epochs since
-    the minimum loss.
+    """Count the number of epochs since the minimum loss in a list of losses.
 
     Args:
         losses (list[float]): List of losses.

--- a/flowjax/train/train_utils.py
+++ b/flowjax/train/train_utils.py
@@ -1,6 +1,7 @@
 """Utility functions for training."""
+from collections.abc import Callable, Sequence
 from functools import partial
-from typing import Any, Callable, Sequence
+from typing import Any
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -82,8 +83,7 @@ def _add_batch(arr, batch_size):
     """Adds a leading dimension for batches, dropping the last batch if truncated."""
     batch_size = min(batch_size, arr.shape[0])
     n_batches = arr.shape[0] // batch_size
-    arr = arr[: n_batches * batch_size].reshape(n_batches, batch_size, *arr.shape[1:])
-    return arr
+    return arr[: n_batches * batch_size].reshape(n_batches, batch_size, *arr.shape[1:])
 
 
 def count_fruitless(losses: list[float]) -> int:

--- a/flowjax/train/train_utils.py
+++ b/flowjax/train/train_utils.py
@@ -8,7 +8,7 @@ import jax.random as jr
 import optax
 from jax import Array, jit
 
-from flowjax.distributions import Distribution
+from flowjax.distributions import AbstractDistribution
 
 PyTree = Any
 
@@ -18,7 +18,7 @@ def step(
     optimizer: optax.GradientTransformation,
     opt_state: PyTree,
     loss_fn: Callable,
-    params: Distribution,
+    params: AbstractDistribution,
     *args,
     **kwargs,
 ):

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -61,7 +61,7 @@ def fit_to_variational_target(
 
     for key in keys:
         params, opt_state, loss = step(
-            optimizer, opt_state, loss_fn, params, static, key
+            optimizer, opt_state, loss_fn, params, static, key,
         )
         losses.append(loss.item())
         keys.set_postfix({"loss": loss.item()})

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -6,7 +6,7 @@ import jax.random as jr
 import optax
 from tqdm import tqdm
 
-from flowjax.distributions import Distribution
+from flowjax.distributions import AbstractDistribution
 from flowjax.train.train_utils import step
 
 PyTree = Any
@@ -14,7 +14,7 @@ PyTree = Any
 
 def fit_to_variational_target(
     key: jr.KeyArray,
-    dist: Distribution,
+    dist: AbstractDistribution,
     loss_fn: Callable,
     steps: int = 100,
     learning_rate: float = 5e-4,

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -1,5 +1,6 @@
 """Basic training script for fitting a flow using variational inference."""
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import equinox as eqx
 import jax.random as jr

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -62,7 +62,12 @@ def fit_to_variational_target(
 
     for key in keys:
         params, opt_state, loss = step(
-            optimizer, opt_state, loss_fn, params, static, key,
+            optimizer,
+            opt_state,
+            loss_fn,
+            params,
+            static,
+            key,
         )
         losses.append(loss.item())
         keys.set_postfix({"loss": loss.item()})

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -5,6 +5,7 @@ from typing import Any
 import equinox as eqx
 import jax.random as jr
 import optax
+from jax import Array
 from tqdm import tqdm
 
 from flowjax.distributions import AbstractDistribution
@@ -14,7 +15,7 @@ PyTree = Any
 
 
 def fit_to_variational_target(
-    key: jr.KeyArray,
+    key: Array,
     dist: AbstractDistribution,
     loss_fn: Callable,
     steps: int = 100,
@@ -26,7 +27,7 @@ def fit_to_variational_target(
     """Train a distribution (e.g. a flow) by variational inference.
 
     Args:
-        key (jr.KeyArray): Jax PRNGKey.
+        key (Array): Jax PRNGKey.
         dist (AbstractDistribution): Distribution object, trainable parameters are found
             using equinox.is_inexact_array.
         loss_fn (Callable | None): The loss function to optimize (e.g. the ElboLoss).

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -22,8 +22,7 @@ def fit_to_variational_target(
     filter_spec: Callable | PyTree = eqx.is_inexact_array,
     show_progress: bool = True,
 ):
-    """Train a distribution (e.g. a flow) by variational inference to a target
-    (e.g. an unnormalized density).
+    """Train a distribution (e.g. a flow) by variational inference.
 
     Args:
         key (jr.KeyArray): Jax PRNGKey.

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -27,7 +27,7 @@ def fit_to_variational_target(
 
     Args:
         key (jr.KeyArray): Jax PRNGKey.
-        dist (Distribution): Distribution object, trainable parameters are found
+        dist (AbstractDistribution): Distribution object, trainable parameters are found
             using equinox.is_inexact_array.
         loss_fn (Callable | None): The loss function to optimize (e.g. the ElboLoss).
         steps (int, optional): The number of training steps to run. Defaults to 100.

--- a/flowjax/utils.py
+++ b/flowjax/utils.py
@@ -10,7 +10,7 @@ from jax.typing import ArrayLike
 
 
 def real_to_increasing_on_interval(
-    arr: Array, B: float = 1, softmax_adjust: float = 1e-2
+    arr: Array, B: float = 1, softmax_adjust: float = 1e-2,
 ):
     """Transform unconstrained vector to monotonically increasing positions on [-B, B].
 
@@ -57,7 +57,7 @@ def check_shapes_match(shapes: list[tuple[int, ...]]):
         if shape != shapes[0]:
             raise ValueError(
                 f"Expected shapes to match, but index 0 had shape {shapes[0]}, and "
-                f"index {i} had shape {shape}."
+                f"index {i} had shape {shape}.",
             )
 
 
@@ -79,7 +79,7 @@ def _get_ufunc_signature(in_shapes: tuple[int], out_shapes: tuple[int]):
 
 
 def get_ravelled_bijection_constructor(
-    bijection, filter_spec=eqx.is_inexact_array
+    bijection, filter_spec=eqx.is_inexact_array,
 ) -> tuple:
     """Get a constructor taking ravelled parameters and the current ravelled parameters.
 
@@ -122,6 +122,6 @@ def arraylike_to_array(arr, err_name: str = "input", **kwargs) -> Array:
     """
     if not isinstance(arr, ArrayLike):
         raise TypeError(
-            f"Expected {err_name} to be arraylike; got {type(arr).__name__}."
+            f"Expected {err_name} to be arraylike; got {type(arr).__name__}.",
         )
     return jnp.asarray(arr, **kwargs)

--- a/flowjax/utils.py
+++ b/flowjax/utils.py
@@ -85,7 +85,7 @@ def get_ravelled_bijection_constructor(bijection, filter_spec=eqx.is_inexact_arr
     parameters.
 
     Args:
-        bijection (Bijection): Bijection.
+        bijection (AbstractBijection): Bijection.
         filter_spec: Filter function. Defaults to eqx.is_inexact_array.
     """
     params, static = eqx.partition(bijection, filter_spec)  # type: ignore

--- a/flowjax/utils.py
+++ b/flowjax/utils.py
@@ -1,5 +1,5 @@
 """Utility functions."""
-from typing import Sequence
+from collections.abc import Sequence
 
 import equinox as eqx
 import jax
@@ -24,7 +24,7 @@ def real_to_increasing_on_interval(
     """
     if softmax_adjust < 0:
         raise ValueError("softmax_adjust should be >= 0.")
-    widths = jax.nn.softmax(arr)  # type: ignore
+    widths = jax.nn.softmax(arr)
     widths = (widths + softmax_adjust / widths.size) / (1 + softmax_adjust)
     widths = widths.at[0].set(widths[0] / 2)
     return 2 * B * jnp.cumsum(widths) - B
@@ -35,7 +35,7 @@ def inv_cum_sum(x):
     return x - jnp.pad(x[:-1], (1, 0))
 
 
-def merge_cond_shapes(shapes: Sequence):
+def merge_cond_shapes(shapes: Sequence[tuple[int, ...] | None]):
     """Merges shapes (tuples of ints or None) used in bijections and distributions.
 
     Returns None if all shapes are None, otherwise checks none None shapes match, and
@@ -51,7 +51,7 @@ def merge_cond_shapes(shapes: Sequence):
     raise ValueError("The shapes do not match.")
 
 
-def check_shapes_match(shapes: list[tuple[int, ...]]):
+def check_shapes_match(shapes: Sequence[tuple[int, ...]]):
     """Check shapes match and produce a useful error message."""
     for i, shape in enumerate(shapes):
         if shape != shapes[0]:
@@ -70,7 +70,7 @@ def _get_ufunc_signature(in_shapes: tuple[int], out_shapes: tuple[int]):
     """
 
     def _shapes_to_str(shapes):
-        result = [str(s) if len(s) != 1 else str(s).replace(",", "") for s in shapes]
+        result = (str(s) if len(s) != 1 else str(s).replace(",", "") for s in shapes)
         return ",".join(result).replace(" ", "")
 
     in_shapes_str = _shapes_to_str(in_shapes)
@@ -96,7 +96,7 @@ def get_ravelled_bijection_constructor(
     Returns:
         tuple: The constructor, and the current parameter vector.
     """
-    params, static = eqx.partition(bijection, filter_spec)  # type: ignore
+    params, static = eqx.partition(bijection, filter_spec)
     current, unravel = ravel_pytree(params)
 
     def constructor(ravelled_params: Array):

--- a/flowjax/utils.py
+++ b/flowjax/utils.py
@@ -10,7 +10,9 @@ from jax.typing import ArrayLike
 
 
 def real_to_increasing_on_interval(
-    arr: Array, B: float = 1, softmax_adjust: float = 1e-2,
+    arr: Array,
+    B: float = 1,
+    softmax_adjust: float = 1e-2,
 ):
     """Transform unconstrained vector to monotonically increasing positions on [-B, B].
 
@@ -79,7 +81,8 @@ def _get_ufunc_signature(in_shapes: tuple[int], out_shapes: tuple[int]):
 
 
 def get_ravelled_bijection_constructor(
-    bijection, filter_spec=eqx.is_inexact_array,
+    bijection,
+    filter_spec=eqx.is_inexact_array,
 ) -> tuple:
     """Get a constructor taking ravelled parameters and the current ravelled parameters.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,11 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 pythonpath = ["."]
 
+
 [tool.ruff]
-select = ["E", "F", "B", "D", "COM", "I", "UP", "TRY004", "RET", "PT", "RUF"]
+select = ["E", "F", "B", "D", "COM", "I", "UP", "TRY004", "RET", "PT"]
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
-ignore = ["D102", "D105"]                                                     # Ignore due to trigerring on inherited docstrings
+ignore = ["D102", "D105"]                                              # Ignore due to trigerring on inherited docstrings
 
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,14 @@ build-backend = "setuptools.build_meta"
 pythonpath = ["."]
 
 [tool.ruff]
-select = ["E", "F", "B"]
+select = ["E", "F", "B", "D"]
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
+ignore = ["D102", "D105"]                                   # Ignore due to trigerring on inherited docstrings
 
 [tool.ruff.pydocstyle]
 convention = "google"
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["D"]
+"*.ipynb" = ["D"]
+"__init__.py" = ["D"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,9 @@ build-backend = "setuptools.build_meta"
 pythonpath = ["."]
 
 [tool.ruff]
-select = ["E", "F", "B", "D"]
+select = ["E", "F", "B", "D", "COM", "I", "UP", "TRY004", "RET", "PT", "RUF"]
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
-ignore = ["D102", "D105"]                                   # Ignore due to trigerring on inherited docstrings
+ignore = ["D102", "D105"]                                                     # Ignore due to trigerring on inherited docstrings
 
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/tests/test_bijections/test_bijection_utils.py
+++ b/tests/test_bijections/test_bijection_utils.py
@@ -17,7 +17,7 @@ test_cases = {
 
 @pytest.mark.parametrize("idx,expected", test_cases.values(), ids=test_cases.keys())
 def test_partial(idx, expected):
-    "Check values only change where we expect"
+    "Check values only change where we expect."
     x = jnp.zeros(4)
     shape = x[idx].shape
     bijection = Partial(Affine(jnp.ones(shape)), idx, x.shape)

--- a/tests/test_bijections/test_bijection_utils.py
+++ b/tests/test_bijections/test_bijection_utils.py
@@ -15,7 +15,9 @@ test_cases = {
 }
 
 
-@pytest.mark.parametrize("idx,expected", test_cases.values(), ids=test_cases.keys())
+@pytest.mark.parametrize(
+        ("idx", "expected"), test_cases.values(), ids=test_cases.keys(),
+        )
 def test_partial(idx, expected):
     "Check values only change where we expect."
     x = jnp.zeros(4)

--- a/tests/test_bijections/test_bijection_utils.py
+++ b/tests/test_bijections/test_bijection_utils.py
@@ -16,8 +16,10 @@ test_cases = {
 
 
 @pytest.mark.parametrize(
-        ("idx", "expected"), test_cases.values(), ids=test_cases.keys(),
-        )
+    ("idx", "expected"),
+    test_cases.values(),
+    ids=test_cases.keys(),
+)
 def test_partial(idx, expected):
     "Check values only change where we expect."
     x = jnp.zeros(4)

--- a/tests/test_bijections/test_bijections.py
+++ b/tests/test_bijections/test_bijections.py
@@ -26,6 +26,7 @@ from flowjax.bijections import (
     Stack,
     Tanh,
     TriangularAffine,
+    Vmap,
 )
 
 DIM = 5
@@ -66,7 +67,7 @@ bijections = {
     "TriangularAffine (weight_norm)": TriangularAffine(
         jnp.arange(DIM), POS_DEF_TRAINGLES, weight_normalisation=True
     ),
-    "RationalQuadraticSpline": RationalQuadraticSpline(knots=4, interval=1, shape=(5,)),
+    "RationalQuadraticSpline": RationalQuadraticSpline(knots=4, interval=1),
     "Coupling (unconditional)": Coupling(
         KEY,
         Affine(),
@@ -130,6 +131,10 @@ bijections = {
     "Planar": Planar(
         KEY,
         DIM,
+    ),
+    "Vmap (broadcast params)": Vmap(Affine(1, 2), axis_size=10),
+    "Vmap (vectorize params)": Vmap(
+        eqx.filter_vmap(Affine)(jnp.ones(3)), eqx.if_array(0)
     ),
 }
 

--- a/tests/test_bijections/test_bijections.py
+++ b/tests/test_bijections/test_bijections.py
@@ -160,7 +160,8 @@ def test_transform_inverse(bijection):
 def test_transform_inverse_and_log_dets(bijection):
     """Tests the transform_and_log_det and inverse_and_log_det methods,
     by 1) checking invertibility and 2) comparing log dets to those obtained with
-    automatic differentiation."""
+    automatic differentiation.
+    """
     shape = bijection.shape if bijection.shape is not None else (DIM,)
     x = jr.normal(jr.PRNGKey(0), shape)
 

--- a/tests/test_bijections/test_bijections.py
+++ b/tests/test_bijections/test_bijections.py
@@ -38,7 +38,7 @@ POS_DEF_TRAINGLES = jnp.full((DIM, DIM), 0.5) + jnp.diag(jnp.ones(DIM))
 def get_maf_layer(key):
     """Get a masked autoregressive flow layer."""
     return MaskedAutoregressive(
-        key, Affine(), DIM, cond_dim=COND_DIM, nn_width=5, nn_depth=5
+        key, Affine(), DIM, cond_dim=COND_DIM, nn_width=5, nn_depth=5,
     )
 
 
@@ -46,11 +46,11 @@ bijections = {
     "Flip": Flip((DIM,)),
     "Permute": Permute(jnp.flip(jnp.arange(DIM))),
     "Permute (3D)": Permute(
-        jnp.reshape(jr.permutation(KEY, jnp.arange(2 * 3 * 4)), (2, 3, 4))
+        jnp.reshape(jr.permutation(KEY, jnp.arange(2 * 3 * 4)), (2, 3, 4)),
     ),
     "Partial (int)": Partial(Affine(jnp.array(2), jnp.array(2)), 0, (DIM,)),
     "Partial (bool array)": Partial(
-        Flip((3,)), jnp.array([True, False, True, False, True]), (DIM,)
+        Flip((3,)), jnp.array([True, False, True, False, True]), (DIM,),
     ),
     "Partial (int array)": Partial(Flip((2,)), jnp.array([0, 4]), (DIM,)),
     "Partial (slice)": Partial(Affine(jnp.zeros(3)), slice(0, 3), (DIM,)),
@@ -62,10 +62,10 @@ bijections = {
     "SoftPlus": SoftPlus((DIM,)),
     "TriangularAffine (lower)": TriangularAffine(jnp.arange(DIM), POS_DEF_TRAINGLES),
     "TriangularAffine (upper)": TriangularAffine(
-        jnp.arange(DIM), POS_DEF_TRAINGLES, lower=False
+        jnp.arange(DIM), POS_DEF_TRAINGLES, lower=False,
     ),
     "TriangularAffine (weight_norm)": TriangularAffine(
-        jnp.arange(DIM), POS_DEF_TRAINGLES, weight_normalisation=True
+        jnp.arange(DIM), POS_DEF_TRAINGLES, weight_normalisation=True,
     ),
     "RationalQuadraticSpline": RationalQuadraticSpline(knots=4, interval=1),
     "Coupling (unconditional)": Coupling(
@@ -87,10 +87,10 @@ bijections = {
         nn_depth=2,
     ),
     "MaskedAutoregressive_Affine (unconditional)": MaskedAutoregressive(
-        KEY, Affine(), cond_dim=0, dim=DIM, nn_width=10, nn_depth=2
+        KEY, Affine(), cond_dim=0, dim=DIM, nn_width=10, nn_depth=2,
     ),
     "MaskedAutoregressive_Affine (conditional)": MaskedAutoregressive(
-        KEY, Affine(), cond_dim=COND_DIM, dim=DIM, nn_width=10, nn_depth=2
+        KEY, Affine(), cond_dim=COND_DIM, dim=DIM, nn_width=10, nn_depth=2,
     ),
     "MaskedAutoregressiveRationalQuadraticSpline (unconditional)": MaskedAutoregressive(
         KEY,
@@ -101,13 +101,13 @@ bijections = {
         nn_depth=2,
     ),
     "BlockAutoregressiveNetwork (unconditional)": BlockAutoregressiveNetwork(
-        KEY, dim=DIM, cond_dim=0, block_dim=3, depth=1
+        KEY, dim=DIM, cond_dim=0, block_dim=3, depth=1,
     ),
     "BlockAutoregressiveNetwork (conditional)": BlockAutoregressiveNetwork(
-        KEY, dim=DIM, cond_dim=COND_DIM, block_dim=3, depth=1
+        KEY, dim=DIM, cond_dim=COND_DIM, block_dim=3, depth=1,
     ),
     "AdditiveCondtition": AdditiveCondition(
-        lambda condition: jnp.arange(DIM) * jnp.sum(condition), (DIM,), (COND_DIM,)
+        lambda condition: jnp.arange(DIM) * jnp.sum(condition), (DIM,), (COND_DIM,),
     ),
     "EmbedCondition": EmbedCondition(
         BlockAutoregressiveNetwork(KEY, dim=DIM, cond_dim=1, block_dim=3, depth=1),
@@ -118,15 +118,15 @@ bijections = {
     "Scan": Scan(eqx.filter_vmap(get_maf_layer)(jr.split(KEY, 3))),
     "Concatenate": Concatenate([Affine(jnp.ones(3)), Tanh(shape=(3,))]),
     "ConcatenateAxis1": Concatenate(
-        [Affine(jnp.ones((3, 3))), Tanh(shape=((3, 3)))], axis=1
+        [Affine(jnp.ones((3, 3))), Tanh(shape=((3, 3)))], axis=1,
     ),
     "ConcatenateAxis-1": Concatenate(
-        [Affine(jnp.ones((3, 3))), Tanh(shape=((3, 3)))], axis=-1
+        [Affine(jnp.ones((3, 3))), Tanh(shape=((3, 3)))], axis=-1,
     ),
     "Stack": Stack([Tanh(()), Affine(), Tanh(())]),
     "StackAxis1": Stack([Tanh((2,)), Affine(jnp.ones(2)), Tanh((2,))], axis=1),
     "StackAxis-1": Stack(
-        [Affine(jr.uniform(k, (1, 2, 3))) for k in jr.split(KEY, 3)], axis=-1
+        [Affine(jr.uniform(k, (1, 2, 3))) for k in jr.split(KEY, 3)], axis=-1,
     ),
     "Planar": Planar(
         KEY,
@@ -134,7 +134,7 @@ bijections = {
     ),
     "Vmap (broadcast params)": Vmap(Affine(1, 2), axis_size=10),
     "Vmap (vectorize params)": Vmap(
-        eqx.filter_vmap(Affine)(jnp.ones(3)), eqx.if_array(0)
+        eqx.filter_vmap(Affine)(jnp.ones(3)), eqx.if_array(0),
     ),
 }
 

--- a/tests/test_bijections/test_chain.py
+++ b/tests/test_bijections/test_chain.py
@@ -1,4 +1,4 @@
-"Tests for bijection.chain module"
+"Tests for bijection.chain module."
 from functools import partial
 
 import equinox as eqx

--- a/tests/test_bijections/test_chain.py
+++ b/tests/test_bijections/test_chain.py
@@ -60,7 +60,7 @@ test_cases = {
 }
 
 
-@pytest.mark.parametrize("scan,chain", test_cases.values(), ids=test_cases.keys())
+@pytest.mark.parametrize(("scan", "chain"), test_cases.values(), ids=test_cases.keys())
 def test_scan(scan, chain):
     "Check Chain and Scan give consistent results."
     x = jnp.ones(DIM)

--- a/tests/test_bijections/test_chain.py
+++ b/tests/test_bijections/test_chain.py
@@ -76,6 +76,6 @@ def test_scan(scan, chain):
     realised = scan.transform_and_log_det(x, condition)
     assert jnp.all(
         jnp.array(
-            [pytest.approx(a) == b for (a, b) in zip(expected, realised, strict=True)]
-        )
+            [pytest.approx(a) == b for (a, b) in zip(expected, realised, strict=True)],
+        ),
     )

--- a/tests/test_bijections/test_jax_transforms.py
+++ b/tests/test_bijections/test_jax_transforms.py
@@ -26,7 +26,7 @@ def test_vmap_uneven_init():
 
 def test_vmap_condition_only():
     bijection = MaskedAutoregressive(
-        jr.PRNGKey(0), Affine(), dim=3, cond_dim=4, nn_width=10, nn_depth=1
+        jr.PRNGKey(0), Affine(), dim=3, cond_dim=4, nn_width=10, nn_depth=1,
     )
 
     with pytest.raises(ValueError):

--- a/tests/test_bijections/test_jax_transforms.py
+++ b/tests/test_bijections/test_jax_transforms.py
@@ -26,12 +26,18 @@ def test_vmap_uneven_init():
 
 def test_vmap_condition_only():
     bijection = MaskedAutoregressive(
-        jr.PRNGKey(0), Affine(), dim=3, cond_dim=4, nn_width=10, nn_depth=1,
+        jr.PRNGKey(0),
+        Affine(),
+        dim=3,
+        cond_dim=4,
+        nn_width=10,
+        nn_depth=1,
     )
 
     with pytest.raises(
-        ValueError, match="Either axis_size or in_axis must be provided.",
-        ):
+        ValueError,
+        match="Either axis_size or in_axis must be provided.",
+    ):
         bijection = Vmap(bijection, in_axis_condition=0)
 
     bijection = Vmap(bijection, in_axis_condition=1, axis_size=10)

--- a/tests/test_bijections/test_jax_transforms.py
+++ b/tests/test_bijections/test_jax_transforms.py
@@ -29,8 +29,10 @@ def test_vmap_condition_only():
         jr.PRNGKey(0), Affine(), dim=3, cond_dim=4, nn_width=10, nn_depth=1,
     )
 
-    with pytest.raises(ValueError):
-        bijection = Vmap(bijection, in_axis_condition=0)  # Need to pass axis size
+    with pytest.raises(
+        ValueError, match="Either axis_size or in_axis must be provided.",
+        ):
+        bijection = Vmap(bijection, in_axis_condition=0)
 
     bijection = Vmap(bijection, in_axis_condition=1, axis_size=10)
     assert bijection.shape == (10, 3)

--- a/tests/test_bijections/test_jax_transforms.py
+++ b/tests/test_bijections/test_jax_transforms.py
@@ -1,0 +1,43 @@
+import equinox as eqx
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+from jax.tree_util import tree_map
+
+from flowjax.bijections import Affine, MaskedAutoregressive, Vmap
+
+
+def test_vmap_uneven_init():
+    "Tests adding a batch dimension to a particular leaf (parameter array)."
+    bijection = Affine(jnp.zeros(()), jnp.ones(()))
+    bijection = eqx.tree_at(lambda bij: bij.loc, bijection, jnp.arange(3))
+    in_axis = tree_map(lambda _: None, bijection)
+    in_axis = eqx.tree_at(lambda bij: bij.loc, in_axis, 0, is_leaf=lambda x: x is None)
+    bijection = Vmap(bijection, in_axis=in_axis)
+
+    assert bijection.shape == (3,)
+    assert bijection.bijection.loc.shape == (3,)
+    assert bijection.bijection.scale.shape == ()
+
+    x = jnp.ones(3)
+    expected = x + jnp.arange(3)
+    assert bijection.transform(x) == pytest.approx(expected)
+
+
+def test_vmap_condition_only():
+    bijection = MaskedAutoregressive(
+        jr.PRNGKey(0), Affine(), dim=3, cond_dim=4, nn_width=10, nn_depth=1
+    )
+
+    with pytest.raises(ValueError):
+        bijection = Vmap(bijection, in_axis_condition=0)  # Need to pass axis size
+
+    bijection = Vmap(bijection, in_axis_condition=1, axis_size=10)
+    assert bijection.shape == (10, 3)
+    assert bijection.cond_shape == (4, 10)
+
+    x = jnp.ones((10, 3))
+    condition = jnp.linspace(-2, 2, 10 * 4).reshape(4, 10)
+    y = bijection.transform(x, condition)
+    x_reconstructed = bijection.inverse(y, condition)
+    assert x_reconstructed == pytest.approx(x)

--- a/tests/test_bijections/test_rational_quadratic_spline.py
+++ b/tests/test_bijections/test_rational_quadratic_spline.py
@@ -2,7 +2,7 @@ import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
-from jax import tree_map
+from jax import tree_map, vmap
 
 from flowjax.bijections import RationalQuadraticSpline
 
@@ -10,14 +10,14 @@ from flowjax.bijections import RationalQuadraticSpline
 def test_RationalQuadraticSpline_tails():
     key = jr.PRNGKey(0)
     x = jnp.array([-20, 0.1, 2, 20])
-    spline = RationalQuadraticSpline(knots=10, interval=3, shape=x.shape)
+    spline = RationalQuadraticSpline(knots=10, interval=3)
 
     # Change to random initialisation, rather than identity.
     spline = tree_map(
         lambda x: jr.normal(key, x.shape) if eqx.is_inexact_array(x) else x, spline
     )
 
-    y = spline.transform(x)
+    y = vmap(spline.transform)(x)
     expected_changed = jnp.array([True, False, False, True])  # identity padding
     assert ((jnp.abs((y - x)) <= 1e-5) == expected_changed).all()
 
@@ -26,13 +26,13 @@ def test_RationalQuadraticSpline_init():
     # Test it is initialised at the identity
     x = jnp.array([-1, 0.1, 2, 1])
     key = jr.PRNGKey(0)
-    spline = RationalQuadraticSpline(knots=10, interval=3, shape=x.shape)
-    y = spline.transform(x)
+    spline = RationalQuadraticSpline(knots=10, interval=3)
+    y = vmap(spline.transform)(x)
     assert pytest.approx(x, abs=1e-6) == y
 
-    shape = spline.bijection.unbounded_derivatives.shape
+    shape = spline.unbounded_derivatives.shape
     spline = eqx.tree_at(
-        lambda b: b.bijection.unbounded_derivatives, spline, jr.normal(key, shape)
+        lambda b: b.unbounded_derivatives, spline, jr.normal(key, shape)
     )
     y = spline.transform(x)
     assert pytest.approx(x, abs=1e-6) != y

--- a/tests/test_bijections/test_rational_quadratic_spline.py
+++ b/tests/test_bijections/test_rational_quadratic_spline.py
@@ -14,7 +14,8 @@ def test_RationalQuadraticSpline_tails():
 
     # Change to random initialisation, rather than identity.
     spline = tree_map(
-        lambda x: jr.normal(key, x.shape) if eqx.is_inexact_array(x) else x, spline,
+        lambda x: jr.normal(key, x.shape) if eqx.is_inexact_array(x) else x,
+        spline,
     )
 
     y = vmap(spline.transform)(x)
@@ -32,7 +33,9 @@ def test_RationalQuadraticSpline_init():
 
     shape = spline.unbounded_derivatives.shape
     spline = eqx.tree_at(
-        lambda b: b.unbounded_derivatives, spline, jr.normal(key, shape),
+        lambda b: b.unbounded_derivatives,
+        spline,
+        jr.normal(key, shape),
     )
     y = spline.transform(x)
     assert pytest.approx(x, abs=1e-6) != y

--- a/tests/test_bijections/test_rational_quadratic_spline.py
+++ b/tests/test_bijections/test_rational_quadratic_spline.py
@@ -19,7 +19,7 @@ def test_RationalQuadraticSpline_tails():
 
     y = vmap(spline.transform)(x)
     expected_changed = jnp.array([True, False, False, True])  # identity padding
-    assert ((jnp.abs((y - x)) <= 1e-5) == expected_changed).all()
+    assert ((jnp.abs(y - x) <= 1e-5) == expected_changed).all()
 
 
 def test_RationalQuadraticSpline_init():

--- a/tests/test_bijections/test_rational_quadratic_spline.py
+++ b/tests/test_bijections/test_rational_quadratic_spline.py
@@ -14,7 +14,7 @@ def test_RationalQuadraticSpline_tails():
 
     # Change to random initialisation, rather than identity.
     spline = tree_map(
-        lambda x: jr.normal(key, x.shape) if eqx.is_inexact_array(x) else x, spline
+        lambda x: jr.normal(key, x.shape) if eqx.is_inexact_array(x) else x, spline,
     )
 
     y = vmap(spline.transform)(x)
@@ -32,7 +32,7 @@ def test_RationalQuadraticSpline_init():
 
     shape = spline.unbounded_derivatives.shape
     spline = eqx.tree_at(
-        lambda b: b.unbounded_derivatives, spline, jr.normal(key, shape)
+        lambda b: b.unbounded_derivatives, spline, jr.normal(key, shape),
     )
     y = spline.transform(x)
     assert pytest.approx(x, abs=1e-6) != y

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -129,10 +129,14 @@ def test_broadcasting_unconditional(dist_shape, sample_shape):
 @pytest.mark.parametrize("sample_shape", sample_shape)
 @pytest.mark.parametrize("condition_shape", condition_shape)
 @pytest.mark.parametrize(
-    "leading_cond_shape", [(), (3, 4)],
+    "leading_cond_shape",
+    [(), (3, 4)],
 )  # Additional leading dimensions in condition
 def test_broadcasting_conditional(
-    dist_shape, sample_shape, condition_shape, leading_cond_shape,
+    dist_shape,
+    sample_shape,
+    condition_shape,
+    leading_cond_shape,
 ):
     key = jr.PRNGKey(0)
     d = _TestDist(dist_shape, condition_shape)
@@ -188,6 +192,7 @@ class _TestCase(NamedTuple):
     args: tuple
     error: Exception
 
+
 unexpected_condition_error = TypeError(
     "Expected condition to be None; got <class 'int'>.",
 )
@@ -228,4 +233,3 @@ test_cases = [
 def test_method_errors(test_case):
     with pytest.raises(type(test_case.error), match=re.escape(test_case.error.args[0])):
         test_case.method(*test_case.args)
-

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -4,8 +4,8 @@ import numpy as np
 import pytest
 
 from flowjax.distributions import (
+    AbstractDistribution,
     Cauchy,
-    Distribution,
     Gumbel,
     Normal,
     StandardNormal,
@@ -100,10 +100,12 @@ def test_uniform_params():
 dist_shape, sample_shape, condition_shape = [[(), (2,), (3, 4)] for _ in range(3)]
 
 
-class _TestDist(Distribution):
+class _TestDist(AbstractDistribution):
     "Toy distribution object, for testing of distribution broadcasting."
+    shape: tuple[int, ...]
+    cond_shape: tuple[int, ...] | None
 
-    def __init__(self, shape, cond_shape=None) -> None:
+    def __init__(self, shape, cond_shape=None):
         self.shape = shape
         self.cond_shape = cond_shape
 
@@ -112,6 +114,9 @@ class _TestDist(Distribution):
 
     def _sample(self, key, condition=None):
         return jnp.zeros(self.shape)
+
+    def _sample_and_log_prob(self, key, condition=None):
+        return jnp.zeros(self.shape), np.zeros(())
 
 
 @pytest.mark.parametrize("dist_shape", dist_shape)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -127,10 +127,10 @@ def test_broadcasting_unconditional(dist_shape, sample_shape):
 @pytest.mark.parametrize("sample_shape", sample_shape)
 @pytest.mark.parametrize("condition_shape", condition_shape)
 @pytest.mark.parametrize(
-    "leading_cond_shape", [(), (3, 4)]
+    "leading_cond_shape", [(), (3, 4)],
 )  # Additional leading dimensions in condition
 def test_broadcasting_conditional(
-    dist_shape, sample_shape, condition_shape, leading_cond_shape
+    dist_shape, sample_shape, condition_shape, leading_cond_shape,
 ):
     key = jr.PRNGKey(0)
     d = _TestDist(dist_shape, condition_shape)
@@ -148,7 +148,7 @@ def test_broadcasting_conditional(
 
 test_cases = [
     StandardNormal(
-        (2, 2)
+        (2, 2),
     ),  # Won't have custom sample_and_log_prob implementation as not Transformed
     Normal(jnp.ones((2, 2))),  # Will have custom implementation as is Transformed
 ]
@@ -184,7 +184,7 @@ def test_transformed_merge_transforms():
 _TestCase = namedtuple("TestCase", "method args error")
 
 unexpected_condition_error = TypeError(
-    "Expected condition to be None; got <class 'int'>."
+    "Expected condition to be None; got <class 'int'>.",
 )
 
 test_cases = [
@@ -213,7 +213,7 @@ test_cases = [
         method=_TestDist((), (2, 3)).log_prob,
         args=(0, jnp.ones((3, 3))),
         error=ValueError(
-            "Expected trailing dimensions matching (2, 3) for condition; got (3, 3)."
+            "Expected trailing dimensions matching (2, 3) for condition; got (3, 3).",
         ),
     ),
 ]

--- a/tests/test_experimental/test_numpyro.py
+++ b/tests/test_experimental/test_numpyro.py
@@ -144,7 +144,7 @@ key = jr.PRNGKey(0)
 test_cases = [[(), ()], [(2,), ()], [(), (2,)], [(3, 2, 4), (1, 2)]]
 
 
-@pytest.mark.parametrize("shape,sample_shape", test_cases)
+@pytest.mark.parametrize(("shape", "sample_shape"), test_cases)
 def test_TransformedToNumpyro(shape, sample_shape):
     key, subkey = jr.split(jr.PRNGKey(0))
     means = jr.normal(subkey, shape)
@@ -207,11 +207,11 @@ def test_batched_condition():
 
 
 def get_conditional_true_guide(key, dim, cond_dim):
-    true_dist, guide_dist = [
+    true_dist, guide_dist = (
         Transformed(
             StandardNormal((dim,)),
             AdditiveCondition(Linear(cond_dim, dim, key=k), (dim,), (cond_dim,)),
         )
         for k in jr.split(key)
-    ]
+    )
     return true_dist, guide_dist

--- a/tests/test_experimental/test_numpyro.py
+++ b/tests/test_experimental/test_numpyro.py
@@ -74,7 +74,7 @@ def test_vi():
     # Test intermediates are used - note BNAF has no inverse so intermediates
     # are required to compute the log_prob in VI.
     guide_dist = BlockNeuralAutoregressiveFlow(
-        key, Normal(jnp.zeros(2), 1), invert=False, nn_block_dim=1
+        key, Normal(jnp.zeros(2), 1), invert=False, nn_block_dim=1,
     )
     svi = SVI(numpyro_model, partial(guide, guide_dist), optimizer, loss=Trace_ELBO())
     svi_result = svi.run(jr.PRNGKey(0), num_steps=2)  # Check runs

--- a/tests/test_experimental/test_numpyro.py
+++ b/tests/test_experimental/test_numpyro.py
@@ -74,7 +74,10 @@ def test_vi():
     # Test intermediates are used - note BNAF has no inverse so intermediates
     # are required to compute the log_prob in VI.
     guide_dist = BlockNeuralAutoregressiveFlow(
-        key, Normal(jnp.zeros(2), 1), invert=False, nn_block_dim=1,
+        key,
+        Normal(jnp.zeros(2), 1),
+        invert=False,
+        nn_block_dim=1,
     )
     svi = SVI(numpyro_model, partial(guide, guide_dist), optimizer, loss=Trace_ELBO())
     svi_result = svi.run(jr.PRNGKey(0), num_steps=2)  # Check runs

--- a/tests/test_experimental/test_numpyro.py
+++ b/tests/test_experimental/test_numpyro.py
@@ -52,7 +52,7 @@ def test_mcmc():
 
 
 def test_vi():
-    "Check that flowjax distributions can be used as guide/variational distributions"
+    "Check that flowjax distributions can be used as guide/variational distributions."
 
     def guide(dist):
         dist = register_params("guide", dist)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -24,10 +24,10 @@ testcases = {
     "TriangularSplineFlow": TriangularSplineFlow(**KWARGS),
     "Affine_Coupling": CouplingFlow(transformer=Affine(), **KWARGS),
     "Spline_Coupling": CouplingFlow(
-        transformer=RationalQuadraticSpline(3, 2), **KWARGS
+        transformer=RationalQuadraticSpline(3, 2), **KWARGS,
     ),
     "Affine_MaskedAutoregessive": MaskedAutoregressiveFlow(
-        transformer=Affine(), **KWARGS
+        transformer=Affine(), **KWARGS,
     ),
     "Planar": PlanarFlow(**KWARGS),
 }
@@ -52,16 +52,16 @@ conditional_testcases = {
     "TriangularSplineFlow": TriangularSplineFlow(**KWARGS, cond_dim=2),
     "Affine_Coupling": CouplingFlow(transformer=Affine(), **KWARGS, cond_dim=2),
     "Spline_Coupling": CouplingFlow(
-        transformer=RationalQuadraticSpline(3, 2), **KWARGS, cond_dim=2
+        transformer=RationalQuadraticSpline(3, 2), **KWARGS, cond_dim=2,
     ),
     "Affine_MaskedAutoregessive": MaskedAutoregressiveFlow(
-        transformer=Affine(), **KWARGS, cond_dim=2
+        transformer=Affine(), **KWARGS, cond_dim=2,
     ),
 }
 
 
 @pytest.mark.parametrize(
-    "flow", conditional_testcases.values(), ids=conditional_testcases.keys()
+    "flow", conditional_testcases.values(), ids=conditional_testcases.keys(),
 )
 def test_conditional_flow_sample(flow):
     cond = jr.normal(KEY, flow.cond_shape)
@@ -72,7 +72,7 @@ def test_conditional_flow_sample(flow):
 
 
 @pytest.mark.parametrize(
-    "flow", conditional_testcases.values(), ids=conditional_testcases.keys()
+    "flow", conditional_testcases.values(), ids=conditional_testcases.keys(),
 )
 def test_conditional_flow_log_prob(flow):
     x = jr.normal(KEY, flow.shape)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -24,10 +24,12 @@ testcases = {
     "TriangularSplineFlow": TriangularSplineFlow(**KWARGS),
     "Affine_Coupling": CouplingFlow(transformer=Affine(), **KWARGS),
     "Spline_Coupling": CouplingFlow(
-        transformer=RationalQuadraticSpline(3, 2), **KWARGS,
+        transformer=RationalQuadraticSpline(3, 2),
+        **KWARGS,
     ),
     "Affine_MaskedAutoregessive": MaskedAutoregressiveFlow(
-        transformer=Affine(), **KWARGS,
+        transformer=Affine(),
+        **KWARGS,
     ),
     "Planar": PlanarFlow(**KWARGS),
 }
@@ -52,16 +54,23 @@ conditional_testcases = {
     "TriangularSplineFlow": TriangularSplineFlow(**KWARGS, cond_dim=2),
     "Affine_Coupling": CouplingFlow(transformer=Affine(), **KWARGS, cond_dim=2),
     "Spline_Coupling": CouplingFlow(
-        transformer=RationalQuadraticSpline(3, 2), **KWARGS, cond_dim=2,
+        transformer=RationalQuadraticSpline(3, 2),
+        **KWARGS,
+        cond_dim=2,
     ),
     "Affine_MaskedAutoregessive": MaskedAutoregressiveFlow(
-        transformer=Affine(), **KWARGS, cond_dim=2,
+        transformer=Affine(),
+        **KWARGS,
+        cond_dim=2,
     ),
+    "Planar": PlanarFlow(**KWARGS, cond_dim=2, width_size=3, depth=1),
 }
 
 
 @pytest.mark.parametrize(
-    "flow", conditional_testcases.values(), ids=conditional_testcases.keys(),
+    "flow",
+    conditional_testcases.values(),
+    ids=conditional_testcases.keys(),
 )
 def test_conditional_flow_sample(flow):
     cond = jr.normal(KEY, flow.cond_shape)
@@ -72,7 +81,9 @@ def test_conditional_flow_sample(flow):
 
 
 @pytest.mark.parametrize(
-    "flow", conditional_testcases.values(), ids=conditional_testcases.keys(),
+    "flow",
+    conditional_testcases.values(),
+    ids=conditional_testcases.keys(),
 )
 def test_conditional_flow_log_prob(flow):
     x = jr.normal(KEY, flow.shape)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -7,6 +7,7 @@ from flowjax.flows import (
     BlockNeuralAutoregressiveFlow,
     CouplingFlow,
     MaskedAutoregressiveFlow,
+    PlanarFlow,
     TriangularSplineFlow,
 )
 
@@ -28,6 +29,7 @@ testcases = {
     "Affine_MaskedAutoregessive": MaskedAutoregressiveFlow(
         transformer=Affine(), **KWARGS
     ),
+    "Planar": PlanarFlow(**KWARGS),
 }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,7 +31,7 @@ test_cases = [
 ]
 
 
-@pytest.mark.parametrize("input_,expected", test_cases)
+@pytest.mark.parametrize(("input_", "expected"), test_cases)
 def test_merge_shapes(input_, expected):
     assert merge_cond_shapes(input_) == expected
 
@@ -41,9 +41,8 @@ test_cases_error = [[(2, 3), (2, 1)], [(2, 3), (4, 2, 3)]]
 
 @pytest.mark.parametrize("input_", test_cases_error)
 def test_merge_shapes_errors(input_):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="The shapes do not match."):
         merge_cond_shapes(input_)
-
 
 test_cases = [
     [([(1, 2)], [(3, 4)]), "(1,2)->(3,4)"],
@@ -54,6 +53,6 @@ test_cases = [
 ]
 
 
-@pytest.mark.parametrize("input_,expected", test_cases)
+@pytest.mark.parametrize(("input_", "expected"), test_cases)
 def test_get_ufunc_signature(input_, expected):
     assert _get_ufunc_signature(*input_) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,6 +44,7 @@ def test_merge_shapes_errors(input_):
     with pytest.raises(ValueError, match="The shapes do not match."):
         merge_cond_shapes(input_)
 
+
 test_cases = [
     [([(1, 2)], [(3, 4)]), "(1,2)->(3,4)"],
     [([(1, 2), (3, 4)], [(5, 6)]), "(1,2),(3,4)->(5,6)"],

--- a/tests/train/test_data_fit.py
+++ b/tests/train/test_data_fit.py
@@ -28,7 +28,12 @@ def test_data_fit_filter_spec():
     filter_spec = jtu.tree_map(eqx.is_inexact_array, flow)
     filter_spec = eqx.tree_at(lambda tree: tree.base_dist, filter_spec, replace=False)
     flow, _ = fit_to_data(
-        random.PRNGKey(0), flow, x, max_epochs=1, batch_size=50, filter_spec=filter_spec
+        key=random.PRNGKey(0),
+        dist=flow,
+        x=x,
+        max_epochs=1,
+        batch_size=50,
+        filter_spec=filter_spec,
     )
     after = eqx.filter(flow, eqx.is_inexact_array)
 

--- a/tests/train/test_train_utils.py
+++ b/tests/train/test_train_utils.py
@@ -19,7 +19,7 @@ def test_train_val_split():
     arrays = [jnp.ones((5, 2)), jnp.ones((3, 5))]
 
     # Axis mismatch
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Array dimensions must match along axis 0"):
         train_val_split(key, arrays, val_prop=0.2)
 
 

--- a/tests/train/test_train_utils.py
+++ b/tests/train/test_train_utils.py
@@ -1,4 +1,4 @@
-"Tests for train_utils.py"
+"Tests for train_utils.py."
 import jax.numpy as jnp
 import jax.random as jr
 import pytest


### PR DESCRIPTION
This aims to shift the design of the package closer to the recommendations [here](https://docs.kidger.site/equinox/pattern/). In doing so, we introduce some breaking changes.

Here is a list of breaking changes:
- ``Distribution`` and ``Bijection`` have been renamed to ``AbstractDistribution`` and ``AbstractBijection`` respectively. Typehints for distributions and bijections should update to use these.
- Custom untransformed distributions should now subtype ``AbstractStandardDistribution``, and explicitly list the ``shape`` and ``cond_shape`` attributes.
-  Custom transformed distributions should subtype ``AbstractTransformed``. The ``shape`` and ``cond_shape`` attributes of ``AbstractTransformed`` are now defined as properties on the class (inferred from the ``base_dist``  and ``bijection``), so they no longer need to be defined.
- Custom bijection implementations must subtype ``AbstractBijection`` and explicitly list the ``shape`` and ``cond_shape`` attributes.
- ``Batch`` bijection has been removed for now in favour of ``Vmap``.
- ``TanhLinearTails`` has been renamed to ``LeakyTanh``.
- ``RationalQuadraticSpline`` no longer has a ``shape`` argument, and instead has the default shape of ``()``, and batch dimensions should be constructed using ``Vmap``.
- Flows no longer contain the string attribute ``permute_strategy``.

