### PR TITLE
Make losses consistent

### DIFF
--- a/flowjax/train/losses.py
+++ b/flowjax/train/losses.py
@@ -24,8 +24,8 @@ class MaximumLikelihoodLoss:
     @eqx.filter_jit
     def __call__(
         self,
-        static: AbstractDistribution,
         params: AbstractDistribution,
+        static: AbstractDistribution,
         x: Array,
         condition: Array | None = None,
     ):
@@ -67,8 +67,8 @@ class ContrastiveLoss:
     @eqx.filter_jit
     def __call__(
         self,
-        static: AbstractDistribution,
         params: AbstractDistribution,
+        static: AbstractDistribution,
         x: Array,
         condition: Array | None = None,
     ):

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -48,11 +48,6 @@ def fit_to_variational_target(
     if optimizer is None:
         optimizer = optax.adam(learning_rate)
 
-    @eqx.filter_value_and_grad
-    def loss_val_and_grad(trainable, static, key):
-        model = eqx.combine(trainable, static)
-        return loss_fn(model, key)
-
     params, static = eqx.partition(dist, filter_spec)
     opt_state = optimizer.init(params)
 
@@ -63,12 +58,12 @@ def fit_to_variational_target(
 
     for key in keys:
         params, opt_state, loss = step(
-            optimizer,
-            opt_state,
-            loss_fn,
             params,
             static,
             key,
+            optimizer=optimizer,
+            opt_state=opt_state,
+            loss_fn=loss_fn,
         )
         losses.append(loss.item())
         keys.set_postfix({"loss": loss.item()})

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -31,9 +31,9 @@ from flowjax.distributions import (
 
 _test_distributions = {
     # flowjax.distributions
-    "StandardNormal": lambda shape: StandardNormal(shape),
+    "StandardNormal": StandardNormal,
     "Normal": lambda shape: Normal(jnp.zeros(shape)),
-    "_StandardUniform": lambda shape: _StandardUniform(shape),
+    "_StandardUniform": _StandardUniform,
     "Uniform": lambda shape: Uniform(jnp.zeros(shape), 1),
     "_StandardGumbel": _StandardGumbel,
     "Gumbel": lambda shape: Gumbel(jnp.zeros(shape)),


### PR DESCRIPTION
Breaking changes:
- Change in the ``step`` function signature in ``flowjax.train.train_utils``. This was (and still is) undocumented in the API.
- Change in losses signature to always have params first (instead of static). Even in custom loss functions, this often wouldn't break anything as ``eqx.combine`` will usually be symmetric in our use cases i.e. ``combine(pytree1, pytree2)`` will equal ``combine(pytree2, pytree1)``, however, code involving loss functions should be updated to pass them in the right order.