### PR TITLE
Ensure int masks and ranks

### DIFF
--- a/flowjax/bijections/masked_autoregressive.py
+++ b/flowjax/bijections/masked_autoregressive.py
@@ -69,7 +69,9 @@ class MaskedAutoregressive(AbstractBijection):
         else:
             self.cond_shape = (cond_dim,)
             # we give conditioning variables rank -1 (no masking of edges to output)
-            in_ranks = jnp.hstack((jnp.arange(dim), -jnp.ones(cond_dim)))
+            in_ranks = jnp.hstack(
+                (jnp.arange(dim), -jnp.ones(cond_dim, dtype=jnp.int32))
+            )
 
         hidden_ranks = jnp.arange(nn_width) % dim
         out_ranks = jnp.repeat(jnp.arange(dim), transformer_init_params.size)

--- a/flowjax/nn/masked_autoregressive.py
+++ b/flowjax/nn/masked_autoregressive.py
@@ -89,7 +89,7 @@ class AutoregressiveMLP(Module):
             key (KeyArray): Jax PRNGKey.
         """
         in_ranks, hidden_ranks, out_ranks = (
-            jnp.asarray(a) for a in (in_ranks, hidden_ranks, out_ranks)
+            jnp.asarray(a, jnp.int32) for a in (in_ranks, hidden_ranks, out_ranks)
         )
         masks = []
         if depth == 0:

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -10,6 +10,7 @@ def test_rank_based_mask():
     expected_mask = jnp.array([[0, 0], [1, 0], [1, 0], [1, 1]], dtype=jnp.int32)
 
     mask = rank_based_mask(in_ranks, out_ranks)
+    assert mask.dtype == jnp.int32
     assert jnp.all(expected_mask == mask)
 
     in_ranks = jnp.array([0, 0, 1, 1])
@@ -17,18 +18,21 @@ def test_rank_based_mask():
 
     expected_mask = jnp.array([[0, 0, 0, 0], [1, 1, 0, 0]], dtype=jnp.int32)
     mask = rank_based_mask(in_ranks, out_ranks)
+    assert mask.dtype == jnp.int32
     assert jnp.all(expected_mask == mask)
 
 
 def test_block_tril_mask():
     args = [(1, 2), 3]
     expected = jnp.array([[0, 0, 0, 0, 0, 0], [1, 1, 0, 0, 0, 0], [1, 1, 1, 1, 0, 0]])
-    result = block_tril_mask(*args)
-    assert jnp.all(expected == result)
+    mask = block_tril_mask(*args)
+    assert mask.dtype == jnp.int32
+    assert jnp.all(expected == mask)
 
 
 def test_block_diag_mask():
     args = [(1, 2), 3]
     expected = jnp.array([[1, 1, 0, 0, 0, 0], [0, 0, 1, 1, 0, 0], [0, 0, 0, 0, 1, 1]])
-    result = block_diag_mask(*args)
-    assert jnp.all(expected == result)
+    mask = block_diag_mask(*args)
+    assert mask.dtype == jnp.int32
+    assert jnp.all(expected == mask)


### PR DESCRIPTION
Fixes ``jnp.ones`` without dtype specified leading to ``in_ranks`` being float dtype.