### PR TITLE
Add identity

### DIFF
--- a/flowjax/bijections/__init__.py
+++ b/flowjax/bijections/__init__.py
@@ -13,7 +13,7 @@ from .planar import Planar
 from .rational_quadratic_spline import RationalQuadraticSpline
 from .softplus import SoftPlus
 from .tanh import LeakyTanh, Tanh
-from .utils import EmbedCondition, Flip, Invert, Partial, Permute
+from .utils import EmbedCondition, Flip, Identity, Invert, Partial, Permute
 
 __all__ = [
     "AdditiveCondition",
@@ -27,6 +27,7 @@ __all__ = [
     "EmbedCondition",
     "Exp",
     "Flip",
+    "Identity",
     "Invert",
     "MaskedAutoregressive",
     "Partial",

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -189,6 +189,33 @@ class Partial(AbstractBijection):
         return self.bijection.cond_shape
 
 
+class Identity(AbstractBijection):
+    """The identity bijection.
+
+    Args:
+       shape (tuple[int, ...]): The shape of the bijection.
+    """
+
+    shape: tuple[int, ...]
+    cond_shape: ClassVar[None] = None
+
+    def transform(self, x, condition=None):
+        x, _ = self._argcheck_and_cast(x)
+        return x
+
+    def transform_and_log_det(self, x, condition=None):
+        x, _ = self._argcheck_and_cast(x)
+        return x, jnp.zeros(())
+
+    def inverse(self, y, condition=None):
+        x, _ = self._argcheck_and_cast(y)
+        return y
+
+    def inverse_and_log_det(self, y, condition=None):
+        x, _ = self._argcheck_and_cast(y)
+        return y, jnp.zeros(())
+
+
 class EmbedCondition(AbstractBijection):
     """Wrap a bijection to include an embedding network.
 

--- a/tests/test_bijections/test_bijections.py
+++ b/tests/test_bijections/test_bijections.py
@@ -15,6 +15,7 @@ from flowjax.bijections import (
     EmbedCondition,
     Exp,
     Flip,
+    Identity,
     LeakyTanh,
     MaskedAutoregressive,
     Partial,
@@ -36,6 +37,7 @@ POS_DEF_TRAINGLES = jnp.full((DIM, DIM), 0.5) + jnp.diag(jnp.ones(DIM))
 
 
 bijections = {
+    "Identity": Identity((DIM,)),
     "Flip": Flip((DIM,)),
     "Permute": Permute(jnp.flip(jnp.arange(DIM))),
     "Permute (3D)": Permute(


### PR DESCRIPTION
Identity bijection. Sometimes useful as a placeholder, or when using `Stack` or `Concatenate` bijections, when we don't want to transform all the inputs.