### PR TITLE
pypi trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   build-n-publish:
     name: Publish to TestPyPI and PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # For pypi trusted publishing
 
     steps:
       - uses: actions/checkout@v3
@@ -16,7 +18,7 @@ jobs:
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.x"
 
       - name: Install pypa/build
         run: python -m pip install build --user
@@ -27,13 +29,10 @@ jobs:
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   docs:
     name: Build and publish documentation
@@ -42,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.x"
       
       - name: Install pandoc
         run: |


### PR DESCRIPTION
Migrate to using https://docs.pypi.org/trusted-publishers/