### PR TITLE
Bijection checks

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -32,6 +32,6 @@ div.wy-nav-content {
     background-color: white;
 }
 
-em.sig-param {
+em {
     font-style: normal;
 }

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1,6 +1,7 @@
 @import url("theme.css");
 
-.wy-side-nav-search, .wy-nav-top {
+.wy-side-nav-search,
+.wy-nav-top {
     background: #fff;
 }
 
@@ -11,7 +12,9 @@
     outline-width: thin;
 }
 
-.wy-menu-vertical a { color: #2f2f2f; }
+.wy-menu-vertical a {
+    color: #2f2f2f;
+}
 
 .wy-menu-vertical a:hover {
     background-color: #c8c8c8;
@@ -27,4 +30,8 @@ section.wy-nav-content-wrap {
 
 div.wy-nav-content {
     background-color: white;
+}
+
+em.sig-param {
+    font-style: normal;
 }

--- a/docs/api/distributions.rst
+++ b/docs/api/distributions.rst
@@ -6,14 +6,3 @@ Distributions from ``flowjax.distributions``.
    :members:
    :show-inheritance:
    :member-order: groupwise
-
-Implementing a custom distribution
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-To implement a custom distribution, subclass
-    -  :class:`~flowjax.distributions.AbstractStandardDistribution` for non-transformed distributions.
-    -  :class:`~flowjax.distributions.AbstractTransformed` for transformed distributions.
-
-For simple examples, check the source code for
-   - :class:`~flowjax.distributions.StandardNormal` as an example of an :class:`~flowjax.distributions.AbstractStandardDistribution`.
-   - :class:`~flowjax.distributions.Normal` as an example of an :class:`~flowjax.distributions.AbstractTransformed`.
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ html_theme_options = {
 
 pygments_style = "xcode"
 autodoc_typehints = "none"
+autodoc_member_order = "bysource"
 
 copybutton_prompt_text = r">>> |\.\.\. "
 copybutton_prompt_is_regexp = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 add_module_names = False
-napoleon_include_init_with_doc = True
+napoleon_include_init_with_doc = False
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -43,7 +43,7 @@ In general you should consider the form and scales of the target samples. For ex
     >>> from flowjax.distributions import Transformed
     >>> preprocess = Affine(-x.mean(axis=0)/x.std(axis=0), 1/x.std(axis=0))
     >>> x_processed = jax.vmap(preprocess.transform)(x)
-    >>> flow, losses = fit_to_data(key, flow, x_processed) # doctest: +SKIP
+    >>> flow, losses = fit_to_data(key, dist=flow, x=x_processed) # doctest: +SKIP
     >>> flow = Transformed(flow, Invert(preprocess))  # "undo" the preprocessing
     
 

--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -91,6 +91,7 @@ class TriangularAffine(AbstractBijection):
         self,
         loc: ArrayLike,
         arr: ArrayLike,
+        *,
         lower: bool = True,
         weight_normalisation: bool = False,
         positivity_constraint: AbstractBijection | None = None,

--- a/flowjax/bijections/bijection.py
+++ b/flowjax/bijections/bijection.py
@@ -30,7 +30,8 @@ def _check_and_cast(method):
 
             if self.cond_shape is not None and condition.shape != self.cond_shape:
                 raise ValueError(
-                    f"Expected condition.shape {self.cond_shape}; got {condition.shape}",
+                    f"Expected condition.shape {self.cond_shape}; got "
+                    f"{condition.shape}",
                 )
             return condition
 
@@ -85,7 +86,8 @@ class AbstractBijection(eqx.Module):
         ]
         for meth in wrap_methods:
             if meth in cls.__dict__ and not hasattr(
-                cls.__dict__[meth], "__isabstractmethod__"
+                cls.__dict__[meth],
+                "__isabstractmethod__",
             ):
                 assert not hasattr(cls.__dict__[meth], "__check_and_cast__")
                 setattr(cls, meth, _check_and_cast(cls.__dict__[meth]))

--- a/flowjax/bijections/bijection.py
+++ b/flowjax/bijections/bijection.py
@@ -18,7 +18,7 @@ from flowjax.utils import arraylike_to_array
 
 
 class _BijectionMeta(type(eqx.Module)):
-    # Metaclass for bijections. This serves wraps the methods to achieve the following.
+    # Metaclass for bijections. This wraps the methods to achieve the following.
     # 1) Enforce input shapes to match the shapes of the bijection.
     # 2) Converts inputs from ArrayLike to Array where appropriate.
     def __new__(

--- a/flowjax/bijections/block_autoregressive_network.py
+++ b/flowjax/bijections/block_autoregressive_network.py
@@ -58,6 +58,7 @@ class BlockAutoregressiveNetwork(AbstractBijection):
     def __init__(
         self,
         key: KeyArray,
+        *,
         dim: int,
         cond_dim: int | None,
         depth: int,

--- a/flowjax/bijections/block_autoregressive_network.py
+++ b/flowjax/bijections/block_autoregressive_network.py
@@ -91,7 +91,14 @@ class BlockAutoregressiveNetwork(AbstractBijection):
 
         layers = []
         if depth == 0:
-            layers.append(BlockAutoregressiveLinear(key, dim, (1, 1), cond_dim))
+            layers.append(
+                BlockAutoregressiveLinear(
+                    key,
+                    n_blocks=dim,
+                    block_shape=(1, 1),
+                    cond_dim=cond_dim,
+                ),
+            )
         else:
             keys = random.split(key, depth + 1)
 
@@ -109,7 +116,12 @@ class BlockAutoregressiveNetwork(AbstractBijection):
                 strict=True,
             ):
                 layers.append(
-                    BlockAutoregressiveLinear(layer_key, dim, block_shape, cond_d),
+                    BlockAutoregressiveLinear(
+                        layer_key,
+                        n_blocks=dim,
+                        block_shape=block_shape,
+                        cond_dim=cond_d,
+                    ),
                 )
 
         self.depth = depth

--- a/flowjax/bijections/block_autoregressive_network.py
+++ b/flowjax/bijections/block_autoregressive_network.py
@@ -47,6 +47,20 @@ class BlockAutoregressiveNetwork(AbstractBijection):
     we use :class:`~flowjax.bijections.tanh.LeakyTanh`. This ensures the codomain of the
     activation is the set of real values, which will ensure properly normalised
     densities (see https://github.com/danielward27/flowjax/issues/102).
+
+    Args:
+        key (KeyArray): Jax PRNGKey
+        dim (int): Dimension of the distribution.
+        cond_dim (tuple[int, ...] | None): Dimension of conditioning variables.
+        depth (int): Number of hidden layers in the network.
+        block_dim (int): Block dimension (hidden layer size is `dim*block_dim`).
+        activation: (Bijection | Callable | None). Activation function, either
+            a scalar bijection or a callable that computes the activation for a
+            scalar value. Note that the activation should be bijective
+            to ensure invertibility of the network and in general should map
+            real -> real to ensure that when transforming a distribution (either
+            with the forward or inverse), the map is defined across the support of
+            the base distribution. Defaults to ``LeakyTanh(3)``.
     """
     shape: tuple[int, ...]
     cond_shape: tuple[int, ...] | None
@@ -65,22 +79,6 @@ class BlockAutoregressiveNetwork(AbstractBijection):
         block_dim: int,
         activation: AbstractBijection | Callable | None = None,
     ):
-        """Initialize the bijection.
-
-        Args:
-            key (KeyArray): Jax PRNGKey
-            dim (int): Dimension of the distribution.
-            cond_dim (tuple[int, ...] | None): Dimension of conditioning variables.
-            depth (int): Number of hidden layers in the network.
-            block_dim (int): Block dimension (hidden layer size is `dim*block_dim`).
-            activation: (Bijection | Callable | None). Activation function, either
-                a scalar bijection or a callable that computes the activation for a
-                scalar value. Note that the activation should be bijective
-                to ensure invertibility of the network and in general should map
-                real -> real to ensure that when transforming a distribution (either
-                with the forward or inverse), the map is defined across the support of
-                the base distribution. Defaults to ``LeakyTanh(3)``.
-        """
         if activation is None:
             activation = LeakyTanh(3)
         elif isinstance(activation, AbstractBijection):

--- a/flowjax/bijections/block_autoregressive_network.py
+++ b/flowjax/bijections/block_autoregressive_network.py
@@ -119,7 +119,6 @@ class BlockAutoregressiveNetwork(AbstractBijection):
         self.activation = activation
 
     def transform(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
         for layer in self.layers[:-1]:
             x = layer(x, condition)[0]
             x = eqx.filter_vmap(self.activation.transform)(x)
@@ -127,7 +126,6 @@ class BlockAutoregressiveNetwork(AbstractBijection):
         return self.layers[-1](x, condition)[0]
 
     def transform_and_log_det(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
         log_jacobian_3ds = []
         for layer in self.layers[:-1]:
             x, log_det_3d = layer(x, condition)

--- a/flowjax/bijections/chain.py
+++ b/flowjax/bijections/chain.py
@@ -6,20 +6,18 @@ from flowjax.utils import check_shapes_match, merge_cond_shapes
 
 
 class Chain(AbstractBijection):
-    """Chain together arbitrary bijections to form another bijection."""
+    """Chain together arbitrary bijections to form another bijection.
+
+    Args:
+        bijections (Sequence[Bijection]): Sequence of bijections. The bijection
+        shapes must match, and any none None condition shapes must match.
+    """
 
     shape: tuple[int, ...]
     cond_shape: tuple[int, ...] | None
     bijections: tuple[AbstractBijection]
 
     def __init__(self, bijections: Sequence[AbstractBijection]):
-        """Initialize the chain bijection.
-
-        Args:
-            bijections (Sequence[Bijection]): Sequence of bijections. The bijection
-            shapes must match, and any none None condition shapes must match.
-
-        """
         check_shapes_match([b.shape for b in bijections])
         self.shape = bijections[0].shape
         self.cond_shape = merge_cond_shapes([b.cond_shape for b in bijections])

--- a/flowjax/bijections/concatenate.py
+++ b/flowjax/bijections/concatenate.py
@@ -13,6 +13,11 @@ class Concatenate(AbstractBijection):
     """Concatenate bijections along an existing axis, similar to ``jnp.concatenate``.
 
     See also :class:`Stack`.
+
+    Args:
+        bijections (Sequence[Bijection]): Bijections, to stack into a single
+            bijection.
+        axis (int): Axis along which to stack. Defaults to 0.
     """
 
     shape: tuple[int, ...]
@@ -22,13 +27,6 @@ class Concatenate(AbstractBijection):
     axis: int
 
     def __init__(self, bijections: Sequence[AbstractBijection], axis: int = 0):
-        """Initialize the bijection.
-
-        Args:
-            bijections (Sequence[Bijection]): Bijections, to stack into a single
-                bijection.
-            axis (int): Axis along which to stack. Defaults to 0.
-        """
         self.bijections = bijections
         self.axis = axis
 
@@ -94,6 +92,10 @@ class Stack(AbstractBijection):
     """Stack bijections along a new axis (analagous to ``jnp.stack``).
 
     See also :class:`Concatenate`.
+
+    Args:
+        bijections (list[Bijection]): Bijections.
+        axis (int): Axis along which to stack. Defaults to 0.
     """
 
     shape: tuple[int, ...]
@@ -102,12 +104,6 @@ class Stack(AbstractBijection):
     axis: int
 
     def __init__(self, bijections: list[AbstractBijection], axis: int = 0):
-        """Initialize the bijection.
-
-        Args:
-            bijections (list[Bijection]): Bijections.
-            axis (int): Axis along which to stack. Defaults to 0.
-        """
         self.axis = axis
         self.bijections = bijections
 

--- a/flowjax/bijections/concatenate.py
+++ b/flowjax/bijections/concatenate.py
@@ -42,7 +42,6 @@ class Concatenate(AbstractBijection):
         self.cond_shape = merge_cond_shapes([b.cond_shape for b in bijections])
 
     def transform(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
         x_parts = jnp.array_split(x, self.split_idxs, axis=self.axis)
         y_parts = [
             b.transform(x_part, condition)
@@ -51,7 +50,6 @@ class Concatenate(AbstractBijection):
         return jnp.concatenate(y_parts, axis=self.axis)
 
     def transform_and_log_det(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
         x_parts = jnp.array_split(x, self.split_idxs, axis=self.axis)
 
         ys_log_dets = [
@@ -63,7 +61,6 @@ class Concatenate(AbstractBijection):
         return jnp.concatenate(y_parts, self.axis), sum(log_dets)
 
     def inverse(self, y, condition=None):
-        y, condition = self._argcheck_and_cast(y, condition)
         y_parts = jnp.array_split(y, self.split_idxs, axis=self.axis)
         x_parts = [
             b.inverse(y_part, condition)
@@ -72,7 +69,6 @@ class Concatenate(AbstractBijection):
         return jnp.concatenate(x_parts, axis=self.axis)
 
     def inverse_and_log_det(self, y, condition=None):
-        y, condition = self._argcheck_and_cast(y, condition)
         y_parts = jnp.array_split(y, self.split_idxs, axis=self.axis)
 
         xs_log_dets = [
@@ -122,7 +118,6 @@ class Stack(AbstractBijection):
         self.cond_shape = merge_cond_shapes([b.cond_shape for b in bijections])
 
     def transform(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
         x_parts = self._split_and_squeeze(x)
         y_parts = [
             b.transform(x, condition)
@@ -131,7 +126,6 @@ class Stack(AbstractBijection):
         return jnp.stack(y_parts, self.axis)
 
     def transform_and_log_det(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
         x_parts = self._split_and_squeeze(x)
         ys_log_det = [
             b.transform_and_log_det(x, condition)
@@ -142,7 +136,6 @@ class Stack(AbstractBijection):
         return jnp.stack(y_parts, self.axis), sum(log_dets)
 
     def inverse(self, y, condition=None):
-        y, condition = self._argcheck_and_cast(y, condition)
         y_parts = self._split_and_squeeze(y)
         x_parts = [
             b.inverse(y, condition)
@@ -151,7 +144,6 @@ class Stack(AbstractBijection):
         return jnp.stack(x_parts, self.axis)
 
     def inverse_and_log_det(self, y, condition=None):
-        y, condition = self._argcheck_and_cast(y, condition)
         y_parts = self._split_and_squeeze(y)
         xs_log_det = [
             b.inverse_and_log_det(y, condition)

--- a/flowjax/bijections/coupling.py
+++ b/flowjax/bijections/coupling.py
@@ -15,7 +15,21 @@ from flowjax.utils import Array, get_ravelled_bijection_constructor
 
 
 class Coupling(AbstractBijection):
-    """Coupling layer implementation (https://arxiv.org/abs/1605.08803)."""
+    """Coupling layer implementation (https://arxiv.org/abs/1605.08803).
+
+    Args:
+        key (KeyArray): Jax PRNGKey
+        transformer (AbstractBijection): Unconditional bijection with shape ()
+            to be parameterised by the conditioner neural netork.
+        untransformed_dim (int): Number of untransformed conditioning variables
+            (e.g. dim // 2).
+        dim (int): Total dimension.
+        cond_dim (int | None): Dimension of additional conditioning variables.
+        nn_width (int): Neural network hidden layer width.
+        nn_depth (int): Neural network hidden layer size.
+        nn_activation (Callable): Neural network activation function.
+            Defaults to jnn.relu.
+    """
 
     shape: tuple[int, ...]
     cond_shape: tuple[int, ...] | None
@@ -36,21 +50,6 @@ class Coupling(AbstractBijection):
         nn_depth: int,
         nn_activation: Callable = jnn.relu,
     ):
-        """Initialize the coupling bijection.
-
-        Args:
-            key (KeyArray): Jax PRNGKey
-            transformer (AbstractBijection): Unconditional bijection with shape ()
-                to be parameterised by the conditioner neural netork.
-            untransformed_dim (int): Number of untransformed conditioning variables
-                (e.g. dim // 2).
-            dim (int): Total dimension.
-            cond_dim (int | None): Dimension of additional conditioning variables.
-            nn_width (int): Neural network hidden layer width.
-            nn_depth (int): Neural network hidden layer size.
-            nn_activation (Callable): Neural network activation function.
-                Defaults to jnn.relu.
-        """
         if transformer.shape != () or transformer.cond_shape is not None:
             raise ValueError(
                 "Only unconditional transformers with shape () are supported.",

--- a/flowjax/bijections/coupling.py
+++ b/flowjax/bijections/coupling.py
@@ -27,6 +27,7 @@ class Coupling(AbstractBijection):
     def __init__(
         self,
         key: KeyArray,
+        *,
         transformer: AbstractBijection,
         untransformed_dim: int,
         dim: int,

--- a/flowjax/bijections/exp.py
+++ b/flowjax/bijections/exp.py
@@ -18,18 +18,14 @@ class Exp(AbstractBijection):
     cond_shape: ClassVar[None] = None
 
     def transform(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         return jnp.exp(x)
 
     def transform_and_log_det(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         return jnp.exp(x), x.sum()
 
     def inverse(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y)
         return jnp.log(y)
 
     def inverse_and_log_det(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y)
         x = jnp.log(y)
         return x, -x.sum()

--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -45,8 +45,6 @@ class Scan(AbstractBijection):
         self.bijection = bijection
 
     def transform(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
-
         def step(x, bijection):
             return (bijection.transform(x, condition), None)
 
@@ -54,8 +52,6 @@ class Scan(AbstractBijection):
         return y
 
     def transform_and_log_det(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
-
         def step(carry, bijection):
             x, log_det = carry
             y, log_det_i = bijection.transform_and_log_det(x, condition)
@@ -65,8 +61,6 @@ class Scan(AbstractBijection):
         return y, log_det
 
     def inverse(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y, condition)
-
         def step(y, bijection):
             return bijection.inverse(y, condition), None
 
@@ -74,8 +68,6 @@ class Scan(AbstractBijection):
         return x
 
     def inverse_and_log_det(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y, condition)
-
         def step(carry, bijection):
             y, log_det = carry
             x, log_det_i = bijection.inverse_and_log_det(y, condition)
@@ -193,8 +185,6 @@ class Vmap(AbstractBijection):
         self.axis_size = axis_size
 
     def transform(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
-
         def _transform(bijection, x, condition):
             return bijection.transform(x, condition)
 
@@ -205,8 +195,6 @@ class Vmap(AbstractBijection):
         )
 
     def transform_and_log_det(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
-
         def _transform_and_log_det(bijection, x, condition):
             return bijection.transform_and_log_det(x, condition)
 
@@ -218,8 +206,6 @@ class Vmap(AbstractBijection):
         return y, jnp.sum(log_det)
 
     def inverse(self, y, condition=None):
-        y, condition = self._argcheck_and_cast(y, condition)
-
         def _inverse(bijection, x, condition):
             return bijection.inverse(x, condition)
 
@@ -230,8 +216,6 @@ class Vmap(AbstractBijection):
         )
 
     def inverse_and_log_det(self, y, condition=None):
-        y, condition = self._argcheck_and_cast(y, condition)
-
         def _inverse_and_log_det(bijection, x, condition):
             return bijection.inverse_and_log_det(x, condition)
 

--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -85,7 +85,7 @@ class Scan(AbstractBijection):
         return self.bijection.cond_shape
 
 
-def _filter_scan(f, init, xs, reverse=False):
+def _filter_scan(f, init, xs, *, reverse=False):
     params, static = eqx.partition(xs, filter_spec=eqx.is_array)
 
     def _scan_fn(carry, x):
@@ -108,14 +108,17 @@ class Vmap(AbstractBijection):
 
             >>> import jax.numpy as jnp
             >>> import equinox as eqx
-            >>> from flowjax.bijections import Vmap, RationalQuadraticSpline
-            >>> bijection = eqx.filter_vmap(RationalQuadraticSpline, axis_size=10)(5, 2)
-            >>> bijection = Vmap(bijection, eqx.if_array(0))
+            >>> from flowjax.bijections import Vmap, RationalQuadraticSpline, Affine
+            >>> bijection = eqx.filter_vmap(
+            ...    lambda: RationalQuadraticSpline(knots=5, interval=2),
+            ...    axis_size=10
+            ... )()
+            >>> bijection = Vmap(bijection, in_axis=eqx.if_array(0))
             >>> bijection.shape
             (10,)
 
             Add a batch dimension to a bijection, broadcasting bijection parameters:
-            >>> bijection = RationalQuadraticSpline(5, 2)
+            >>> bijection = RationalQuadraticSpline(knots=5, interval=2)
             >>> bijection = Vmap(bijection, axis_size=10)
             >>> bijection.shape
             (10,)

--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -154,6 +154,7 @@ class Vmap(AbstractBijection):
     def __init__(
         self,
         bijection: AbstractBijection,
+        *,
         in_axis: int | None | Callable = None,
         axis_size: int | None = None,
         in_axis_condition: int | None = None,

--- a/flowjax/bijections/masked_autoregressive.py
+++ b/flowjax/bijections/masked_autoregressive.py
@@ -35,6 +35,7 @@ class MaskedAutoregressive(AbstractBijection):
     def __init__(
         self,
         key: KeyArray,
+        *,
         transformer: AbstractBijection,
         dim: int,
         cond_dim: int | None,

--- a/flowjax/bijections/masked_autoregressive.py
+++ b/flowjax/bijections/masked_autoregressive.py
@@ -22,9 +22,19 @@ class MaskedAutoregressive(AbstractBijection):
     The transformer is parameterised by a neural network, with weights masked to ensure
     an autoregressive structure.
 
-    Ref:
+    Refs:
         - https://arxiv.org/abs/1705.07057v4
         - https://arxiv.org/abs/1705.07057v4
+
+    Args:
+        key (KeyArray): Jax PRNGKey
+        transformer (AbstractBijection): Bijection with shape () to be parameterised
+        by the autoregressive network.
+        dim (int): Dimension.
+        cond_dim (int | None): Dimension of any conditioning variables.
+        nn_width (int): Neural network width.
+        nn_depth (int): Neural network depth.
+        nn_activation (Callable): Neural network activation. Defaults to jnn.relu.
     """
 
     shape: tuple[int, ...]
@@ -43,18 +53,6 @@ class MaskedAutoregressive(AbstractBijection):
         nn_depth: int,
         nn_activation: Callable = jnn.relu,
     ) -> None:
-        """Initialize the masked autoregressive bijection.
-
-        Args:
-            key (KeyArray): Jax PRNGKey
-            transformer (AbstractBijection): Bijection with shape () to be parameterised
-            by the autoregressive network.
-            dim (int): Dimension.
-            cond_dim (int | None): Dimension of any conditioning variables.
-            nn_width (int): Neural network width.
-            nn_depth (int): Neural network depth.
-            nn_activation (Callable): Neural network activation. Defaults to jnn.relu.
-        """
         if transformer.shape != () or transformer.cond_shape is not None:
             raise ValueError(
                 "Only unconditional transformers with shape () are supported.",

--- a/flowjax/bijections/planar.py
+++ b/flowjax/bijections/planar.py
@@ -12,7 +12,7 @@ from jax import Array
 from jax.nn import softplus
 from jax.numpy.linalg import norm
 
-from flowjax.bijections import AbstractBijection
+from flowjax.bijections.bijection import AbstractBijection
 
 
 class Planar(AbstractBijection):
@@ -57,11 +57,9 @@ class Planar(AbstractBijection):
             self.cond_shape = (cond_dim,)
 
     def transform(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
         return self.get_planar(condition).transform(x)
 
     def transform_and_log_det(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
         return self.get_planar(condition).transform_and_log_det(x)
 
     def inverse(self, y, condition=None):

--- a/flowjax/bijections/planar.py
+++ b/flowjax/bijections/planar.py
@@ -31,6 +31,7 @@ class Planar(AbstractBijection):
     def __init__(
         self,
         key: Array,
+        *,
         dim: int,
         cond_dim: int | None = None,
         **mlp_kwargs,

--- a/flowjax/bijections/planar.py
+++ b/flowjax/bijections/planar.py
@@ -22,6 +22,14 @@ class Planar(AbstractBijection):
     :math:`u \in \mathbb{R}^D, \ w \in \mathbb{R}^D` and :math:`b \in \mathbb{R}`. In
     the unconditional case, :math:`w`, :math:`u`  and :math:`b` are learned directly.
     In the conditional case they are parameterised by an MLP.
+
+    Args:
+        key (Array): Jax random seed.
+        dim (int): Dimension of the bijection.
+        cond_dim (int | None, optional): Dimension of extra conditioning variables.
+            Defaults to None.
+        **mlp_kwargs: Key word arguments (excluding in_size and out_size) passed to
+            the MLP (equinox.nn.MLP). Ignored when cond_dim is None.
     """
     shape: tuple[int, ...]
     cond_shape: tuple[int, ...] | None
@@ -36,16 +44,6 @@ class Planar(AbstractBijection):
         cond_dim: int | None = None,
         **mlp_kwargs,
     ):
-        """Initialize the bijection.
-
-        Args:
-            key (Array): Jax random seed.
-            dim (int): Dimension of the bijection.
-            cond_dim (int | None, optional): Dimension of extra conditioning variables.
-                Defaults to None.
-            **mlp_kwargs: Key word arguments (excluding in_size and out_size) passed to
-                the MLP (equinox.nn.MLP). Ignored when cond_dim is None.
-        """
         self.shape = (dim,)
 
         if cond_dim is None:
@@ -81,7 +79,11 @@ class Planar(AbstractBijection):
 
 
 class _UnconditionalPlanar(AbstractBijection):
-    """Unconditional planar bijection, used in Planar."""
+    """Unconditional planar bijection, used in Planar.
+
+    Note act_scale (u in the paper) is unconstrained and the constraint to ensure
+    invertiblitiy is applied in the ``get_act_scale``.
+    """
 
     shape: tuple[int, ...]
     cond_shape: ClassVar[None] = None
@@ -90,11 +92,6 @@ class _UnconditionalPlanar(AbstractBijection):
     bias: Array
 
     def __init__(self, weight, act_scale, bias):
-        """Construct an unconditional planar bijection.
-
-        Note act_scale (u in the paper) is unconstrained and the constraint to ensure
-        invertiblitiy is applied in the ``get_act_scale``.
-        """
         self.weight = weight
         self._act_scale = act_scale
         self.bias = bias

--- a/flowjax/bijections/rational_quadratic_spline.py
+++ b/flowjax/bijections/rational_quadratic_spline.py
@@ -12,7 +12,17 @@ from flowjax.utils import real_to_increasing_on_interval
 
 
 class RationalQuadraticSpline(AbstractBijection):
-    """Scalar RationalQuadraticSpline transformation (https://arxiv.org/abs/1906.04032)."""
+    """Scalar RationalQuadraticSpline transformation (https://arxiv.org/abs/1906.04032).
+
+    Args:
+        knots (int): Number of knots.
+        interval (float): interval to transform, [-interval, interval].
+        min_derivative (float): Minimum dervivative. Defaults to 1e-3.
+        softmax_adjust (float): Controls minimum bin width and height by
+            rescaling softmax output, e.g. 0=no adjustment, 1=average softmax output
+            with evenly spaced widths, >1 promotes more evenly spaced widths.
+            See ``real_to_increasing_on_interval``. Defaults to 1e-2.
+    """
 
     shape: ClassVar[tuple] = ()
     cond_shape: ClassVar[None] = None
@@ -32,17 +42,6 @@ class RationalQuadraticSpline(AbstractBijection):
         min_derivative: float = 1e-3,
         softmax_adjust: float = 1e-2,
     ):
-        """Initialize the RationalQuadraticSpline bijection.
-
-        Args:
-            knots (int): Number of knots.
-            interval (float): interval to transform, [-interval, interval].
-            min_derivative (float): Minimum dervivative. Defaults to 1e-3.
-            softmax_adjust (float): Controls minimum bin width and height by
-                rescaling softmax output, e.g. 0=no adjustment, 1=average softmax output
-                with evenly spaced widths, >1 promotes more evenly spaced widths.
-                See ``real_to_increasing_on_interval``. Defaults to 1e-2.
-        """
         self.knots = knots
         self.interval = interval
         self.softmax_adjust = softmax_adjust

--- a/flowjax/bijections/rational_quadratic_spline.py
+++ b/flowjax/bijections/rational_quadratic_spline.py
@@ -27,6 +27,7 @@ class RationalQuadraticSpline(AbstractBijection):
     def __init__(
         self,
         knots: int,
+        *,
         interval: float,
         min_derivative: float = 1e-3,
         softmax_adjust: float = 1e-2,

--- a/flowjax/bijections/rational_quadratic_spline.py
+++ b/flowjax/bijections/rational_quadratic_spline.py
@@ -26,8 +26,8 @@ class RationalQuadraticSpline(AbstractBijection):
 
     def __init__(
         self,
-        knots: int,
         *,
+        knots: int,
         interval: float,
         min_derivative: float = 1e-3,
         softmax_adjust: float = 1e-2,

--- a/flowjax/bijections/softplus.py
+++ b/flowjax/bijections/softplus.py
@@ -13,18 +13,14 @@ class SoftPlus(AbstractBijection):
     cond_shape: ClassVar[None] = None
 
     def transform(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         return softplus(x)
 
     def transform_and_log_det(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         return softplus(x), -softplus(-x).sum()
 
     def inverse(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y)
         return jnp.log(-jnp.expm1(-y)) + y
 
     def inverse_and_log_det(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y)
         x = self.inverse(y)
         return x, softplus(-x).sum()

--- a/flowjax/bijections/tanh.py
+++ b/flowjax/bijections/tanh.py
@@ -20,19 +20,15 @@ class Tanh(AbstractBijection):
     cond_shape: ClassVar[None] = None
 
     def transform(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         return jnp.tanh(x)
 
     def transform_and_log_det(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         return jnp.tanh(x), jnp.sum(_tanh_log_grad(x))
 
     def inverse(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y)
         return jnp.arctanh(y)
 
     def inverse_and_log_det(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y)
         x = jnp.arctanh(y)
         return x, -jnp.sum(_tanh_log_grad(x))
 
@@ -65,14 +61,12 @@ class LeakyTanh(AbstractBijection):
         self.shape = shape
 
     def transform(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         is_linear = jnp.abs(x) >= self.max_val
         linear_y = self.linear_grad * x + jnp.sign(x) * self.intercept
         tanh_y = jnp.tanh(x)
         return jnp.where(is_linear, linear_y, tanh_y)
 
     def transform_and_log_det(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         y = self.transform(x)
         log_grads = jnp.where(
             jnp.abs(x) >= self.max_val,
@@ -82,14 +76,12 @@ class LeakyTanh(AbstractBijection):
         return y, jnp.sum(log_grads)
 
     def inverse(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y)
         is_linear = jnp.abs(y) >= jnp.tanh(self.max_val)
         x_linear = (y - jnp.sign(y) * self.intercept) / self.linear_grad
         x_arctan = jnp.arctanh(y)
         return jnp.where(is_linear, x_linear, x_arctan)
 
     def inverse_and_log_det(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y)
         x = self.inverse(y)
         log_grads = jnp.where(
             jnp.abs(y) >= jnp.tanh(self.max_val),

--- a/flowjax/bijections/tanh.py
+++ b/flowjax/bijections/tanh.py
@@ -40,6 +40,10 @@ class LeakyTanh(AbstractBijection):
     This bijection can be useful to encourage values to be within an interval, whilst
     avoiding numerical precision issues, or in cases we require a real -> real mapping
     so Tanh is not appropriate.
+
+    Args:
+        max_val (float): Value above or below which the function becomes linear.
+        shape (tuple[int, ...] | None): The shape of the bijection. Defaults to ().
     """
 
     shape: tuple[int, ...] = ()
@@ -49,12 +53,6 @@ class LeakyTanh(AbstractBijection):
     linear_grad: float
 
     def __init__(self, max_val: float, shape: tuple[int, ...] = ()):
-        """Initialize the leaky tanh bijection.
-
-        Args:
-            max_val (float): Value above or below which the function becomes linear.
-            shape (tuple[int, ...] | None): The shape of the bijection. Defaults to ().
-        """
         self.max_val = float(max_val)
         self.linear_grad = math.exp(_tanh_log_grad(max_val))
         self.intercept = math.tanh(max_val) - self.linear_grad * max_val

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -87,19 +87,15 @@ class Permute(AbstractBijection):
         )
 
     def transform(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         return x[self.permutation]
 
     def transform_and_log_det(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         return x[self.permutation], jnp.array(0)
 
     def inverse(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y)
         return y[self.inverse_permutation]
 
     def inverse_and_log_det(self, y, condition=None):
-        x, _ = self._argcheck_and_cast(y)
         return y[self.inverse_permutation], jnp.array(0)
 
 
@@ -115,19 +111,15 @@ class Flip(AbstractBijection):
     cond_shape: ClassVar[None] = None
 
     def transform(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         return jnp.flip(x)
 
     def transform_and_log_det(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         return jnp.flip(x), jnp.array(0)
 
     def inverse(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y)
         return jnp.flip(y)
 
     def inverse_and_log_det(self, y, condition=None):
-        y, _ = self._argcheck_and_cast(y)
         return jnp.flip(y), jnp.array(0)
 
 
@@ -165,22 +157,18 @@ class Partial(AbstractBijection):
             )
 
     def transform(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
         y = self.bijection.transform(x[self.idxs], condition)
         return x.at[self.idxs].set(y)
 
     def transform_and_log_det(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
         y, log_det = self.bijection.transform_and_log_det(x[self.idxs], condition)
         return x.at[self.idxs].set(y), log_det
 
     def inverse(self, y, condition=None):
-        y, condition = self._argcheck_and_cast(y, condition)
         x = self.bijection.inverse(y[self.idxs], condition)
         return y.at[self.idxs].set(x)
 
     def inverse_and_log_det(self, y, condition=None):
-        y, condition = self._argcheck_and_cast(y, condition)
         x, log_det = self.bijection.inverse_and_log_det(y[self.idxs], condition)
         return y.at[self.idxs].set(x), log_det
 
@@ -248,22 +236,18 @@ class EmbedCondition(AbstractBijection):
         self.cond_shape = raw_cond_shape
 
     def transform(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
         condition = self.embedding_net(condition)
         return self.bijection.transform(x, condition)
 
     def transform_and_log_det(self, x, condition=None):
-        x, condition = self._argcheck_and_cast(x, condition)
         condition = self.embedding_net(condition)
         return self.bijection.transform_and_log_det(x, condition)
 
     def inverse(self, y, condition=None):
-        y, condition = self._argcheck_and_cast(y, condition)
         condition = self.embedding_net(condition)
         return self.bijection.inverse(y, condition)
 
     def inverse_and_log_det(self, y, condition=None):
-        y, condition = self._argcheck_and_cast(y, condition)
         condition = self.embedding_net(condition)
         return self.bijection.inverse_and_log_det(y, condition)
 

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -188,19 +188,15 @@ class Identity(AbstractBijection):
     cond_shape: ClassVar[None] = None
 
     def transform(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         return x
 
     def transform_and_log_det(self, x, condition=None):
-        x, _ = self._argcheck_and_cast(x)
         return x, jnp.zeros(())
 
     def inverse(self, y, condition=None):
-        x, _ = self._argcheck_and_cast(y)
         return y
 
     def inverse_and_log_det(self, y, condition=None):
-        x, _ = self._argcheck_and_cast(y)
         return y, jnp.zeros(())
 
 

--- a/flowjax/distributions.py
+++ b/flowjax/distributions.py
@@ -123,7 +123,7 @@ class AbstractDistribution(eqx.Module):
                 dist = StandardNormal((2,))
                 # For a conditional distribution
                 cond_dist = coupling_flow(
-                    key, StandardNormal((2,)), cond_dim=3, transformer=Affine()
+                    key, base_dist=StandardNormal((2,)), cond_dim=3
                     )
 
             For an unconditional distribution:
@@ -223,7 +223,9 @@ class AbstractDistribution(eqx.Module):
             def _wrapper(*args, **kwargs):
                 bound = inspect.signature(method).bind(*args, **kwargs)
                 for in_shape, (name, arg) in zip(
-                    in_shapes, bound.arguments.items(), strict=False
+                    in_shapes,
+                    bound.arguments.items(),
+                    strict=False,
                 ):
                     if arg.shape != in_shape:
                         raise ValueError(
@@ -629,6 +631,7 @@ class SpecializeCondition(AbstractDistribution):  # TODO check tested
         self,
         dist: AbstractDistribution,
         condition: ArrayLike,
+        *,
         stop_gradient: bool = True,
     ):
         """Initialize the distribution.

--- a/flowjax/distributions.py
+++ b/flowjax/distributions.py
@@ -350,14 +350,6 @@ class Transformed(AbstractTransformed):
     base_dist: AbstractDistribution
     bijection: AbstractBijection
 
-    def __init__(
-        self,
-        base_dist: AbstractDistribution,
-        bijection: AbstractBijection,
-    ):
-        self.base_dist = base_dist
-        self.bijection = bijection
-
 
 class StandardNormal(AbstractDistribution):
     """Standard normal distribution.

--- a/flowjax/distributions.py
+++ b/flowjax/distributions.py
@@ -250,8 +250,8 @@ class AbstractTransformed(AbstractDistribution):
     density evaluation. See also :class:`Transformed`.
 
     Concete implementations should subclass :class:`AbstractTransformed`, and
-    define the abstract attributes `base_dist` and `bijection`. See the source code for
-    :class:`Normal` as a simple example.
+    define the abstract attributes ``base_dist`` and ``bijection``. See the source code
+    for :class:`Normal` as a simple example.
     """
 
     base_dist: AbstractVar[AbstractDistribution]

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -38,15 +38,13 @@ PyTree = Any
 
 
 class _VectorizedBijection:
-    """Wrap a flowjax bijection to support vectorization."""
+    """Wrap a flowjax bijection to support vectorization.
+
+    Args:
+        bijection (AbstractBijection): flowjax bijection to be wrapped.
+    """
 
     def __init__(self, bijection: AbstractBijection):
-        """Initialize the vectorized bijection.
-
-        Args:
-            bijection (AbstractBijection): flowjax bijection to be wrapped.
-            Defaults to constraints.real.
-        """
         self.bijection = bijection
         self.shape = self.bijection.shape
         self.cond_shape = self.bijection.cond_shape
@@ -83,6 +81,12 @@ class TransformedToNumpyro(numpyro.distributions.Distribution):
     """Convert a :class:`Transformed` flowjax distribution to a numpyro distribution.
 
     We assume the support of the distribution is unbounded.
+
+    Args:
+        dist (AbstractTransformed): The distribution.
+        condition (ArrayLike | None, optional): Conditioning variables. Any
+            leading batch dimensions will be converted to a batch dimension in
+            the numpyro distribution. Defaults to None.
     """
 
     def __init__(
@@ -90,14 +94,6 @@ class TransformedToNumpyro(numpyro.distributions.Distribution):
         dist: AbstractTransformed,
         condition: ArrayLike | None = None,
     ):
-        """Initialize the numpyro distribution.
-
-        Args:
-            dist (AbstractTransformed): The distribution
-            condition (ArrayLike | None, optional): Conditioning variables. Any
-            leading batch dimensions will be converted to a batch dimension in
-            the numpyro distribution. Defaults to None.
-        """
         if condition is not None:
             condition = arraylike_to_array(condition, "condition")
             batch_shape = (

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -66,7 +66,7 @@ class _VectorizedBijection:
         )
         return transform_and_log_det(x, condition)
 
-    def vectorize(self, func, log_det=False):
+    def vectorize(self, func, *, log_det=False):
         in_shapes, out_shapes = [self.bijection.shape], [self.bijection.shape]
         if log_det:
             out_shapes.append(())

--- a/flowjax/flows.py
+++ b/flowjax/flows.py
@@ -32,6 +32,7 @@ from flowjax.bijections import (
     Scan,
     TriangularAffine,
     Vmap,
+    Affine,
 )
 from flowjax.distributions import AbstractDistribution, Transformed
 
@@ -40,7 +41,7 @@ def coupling_flow(
     key: Array,
     *,
     base_dist: AbstractDistribution,
-    transformer: AbstractBijection,
+    transformer: AbstractBijection | None = None,
     cond_dim: int | None = None,
     flow_layers: int = 8,
     nn_width: int = 50,
@@ -54,7 +55,7 @@ def coupling_flow(
         key (Array): Jax random number generator key.
         base_dist (AbstractDistribution): Base distribution, with ``base_dist.ndim==1``.
         transformer (AbstractBijection): Bijection to be parameterised by
-        conditioner.
+        conditioner. Defaults to ``Affine()``.
         cond_dim (int): Dimension of conditioning variables. Defaults to None.
         flow_layers (int): Number of coupling layers. Defaults to 5.
         nn_width (int): Conditioner hidden layer size. Defaults to 40.
@@ -65,6 +66,7 @@ def coupling_flow(
             False will prioritise faster `transform` methods, leading to faster
             `sample`. Defaults to True.
     """
+    transformer = Affine() if transformer is None else transformer
     dim = base_dist.shape[-1]
 
     def make_layer(key):  # coupling layer + permutation
@@ -91,7 +93,7 @@ def masked_autoregressive_flow(
     key: Array,
     *,
     base_dist: AbstractDistribution,
-    transformer: AbstractBijection,
+    transformer: AbstractBijection | None = None,
     cond_dim: int | None = None,
     flow_layers: int = 8,
     nn_width: int = 50,
@@ -108,7 +110,7 @@ def masked_autoregressive_flow(
         key (Array): Random seed.
         base_dist (AbstractDistribution): Base distribution, with ``base_dist.ndim==1``.
         transformer (AbstractBijection): Bijection parameterised by autoregressive
-            network.
+            network. Defaults to ``Affine()``.
         cond_dim (int): _description_. Defaults to 0.
         flow_layers (int): Number of flow layers. Defaults to 5.
         nn_width (int): Number of hidden layers in neural network. Defaults to 40.
@@ -118,6 +120,7 @@ def masked_autoregressive_flow(
             prioritise a faster inverse, leading to faster `log_prob`, False will
             prioritise faster forward, leading to faster `sample`. Defaults to True.
     """
+    transformer = Affine() if transformer is None else transformer
     dim = base_dist.shape[-1]
 
     def make_layer(key):  # masked autoregressive layer + permutation

--- a/flowjax/masks.py
+++ b/flowjax/masks.py
@@ -12,7 +12,7 @@ from jax import Array
 from jax.scipy.linalg import block_diag
 
 
-def rank_based_mask(in_ranks: Array, out_ranks: Array, eq: bool = False):
+def rank_based_mask(in_ranks: Array, out_ranks: Array, *, eq: bool = False):
     """Forms mask matrix, with 1s where the out_ranks > or >= in_ranks.
 
     Args:

--- a/flowjax/nn/block_autoregressive.py
+++ b/flowjax/nn/block_autoregressive.py
@@ -15,6 +15,15 @@ class BlockAutoregressiveLinear(eqx.Module):
 
     Conditioning variables are incorporated by appending columns (one for each
     conditioning variable) to the right of the block diagonal weight matrix.
+
+    Args:
+        key (KeyArray): Random key
+        n_blocks (int): Number of diagonal blocks (dimension of original input).
+        block_shape (tuple): The shape of the (unconstrained) blocks.
+        cond_dim (int | None): Number of additional conditioning variables.
+            Defaults to None.
+        init (Callable | None): Default initialisation method for the weight
+            matrix. Defaults to ``glorot_uniform()``.
     """
 
     n_blocks: int
@@ -38,17 +47,6 @@ class BlockAutoregressiveLinear(eqx.Module):
         cond_dim: int | None = None,
         init: Callable | None = None,
     ):
-        """Initialize the block autoregressive linear layer.
-
-        Args:
-            key (KeyArray): Random key
-            n_blocks (int): Number of diagonal blocks (dimension of original input).
-            block_shape (tuple): The shape of the (unconstrained) blocks.
-            cond_dim (int | None): Number of additional conditioning variables.
-                Defaults to None.
-            init (Callable | None): Default initialisation method for the weight
-                matrix. Defaults to ``glorot_uniform()``.
-        """
         init = init if init is not None else glorot_uniform()
         self.cond_dim = cond_dim
 

--- a/flowjax/nn/block_autoregressive.py
+++ b/flowjax/nn/block_autoregressive.py
@@ -32,6 +32,7 @@ class BlockAutoregressiveLinear(eqx.Module):
     def __init__(
         self,
         key: KeyArray,
+        *,
         n_blocks: int,
         block_shape: tuple,
         cond_dim: int | None = None,

--- a/flowjax/nn/masked_autoregressive.py
+++ b/flowjax/nn/masked_autoregressive.py
@@ -22,7 +22,7 @@ class MaskedLinear(Module):
     linear: Linear
     mask: Array
 
-    def __init__(self, mask: ArrayLike, use_bias: bool = True, *, key: KeyArray):
+    def __init__(self, mask: ArrayLike, *, use_bias: bool = True, key: KeyArray):
         """Initialize the masked linear layer.
 
         Args:

--- a/flowjax/nn/masked_autoregressive.py
+++ b/flowjax/nn/masked_autoregressive.py
@@ -17,19 +17,18 @@ def _identity(x):
 
 
 class MaskedLinear(Module):
-    """Masked linear neural network layer."""
+    """Masked linear neural network layer.
+
+    Args:
+        mask (ArrayLike): Mask with shape (out_features, in_features).
+        key (KeyArray): Jax PRNGKey
+        use_bias (bool): Whether to include bias terms. Defaults to True.
+    """
 
     linear: Linear
     mask: Array
 
     def __init__(self, mask: ArrayLike, *, use_bias: bool = True, key: KeyArray):
-        """Initialize the masked linear layer.
-
-        Args:
-            mask (ArrayLike): Mask with shape (out_features, in_features).
-            key (KeyArray): Jax PRNGKey
-            use_bias (bool): Whether to include bias terms. Defaults to True.
-        """
         mask = jnp.asarray(mask)
         self.linear = Linear(mask.shape[1], mask.shape[0], use_bias, key=key)
         self.mask = mask
@@ -52,6 +51,16 @@ class AutoregressiveMLP(Module):
 
     Similar to ``equinox.nn.composed.MLP``, however, connections will only exist between
     nodes where in_ranks < out_ranks.
+
+    Args:
+        in_ranks (ArrayLike): Ranks of the inputs.
+        hidden_ranks (ArrayLike): Ranks of the hidden layer(s).
+        out_ranks (ArrayLike): Ranks of the outputs.
+        depth (int): Number of hidden layers.
+        activation (Callable): Activation function. Defaults to jnn.relu.
+        final_activation (Callable): Final activation function. Defaults to
+            _identity.
+        key (KeyArray): Jax PRNGKey.
     """
 
     in_size: int
@@ -76,18 +85,6 @@ class AutoregressiveMLP(Module):
         *,
         key,
     ) -> None:
-        """Initialize the autoregressive multilayer perceptron.
-
-        Args:
-            in_ranks (ArrayLike): Ranks of the inputs.
-            hidden_ranks (ArrayLike): Ranks of the hidden layer(s).
-            out_ranks (ArrayLike): Ranks of the outputs.
-            depth (int): Number of hidden layers.
-            activation (Callable): Activation function. Defaults to jnn.relu.
-            final_activation (Callable): Final activation function. Defaults to
-                _identity.
-            key (KeyArray): Jax PRNGKey.
-        """
         in_ranks, hidden_ranks, out_ranks = (
             jnp.asarray(a, jnp.int32) for a in (in_ranks, hidden_ranks, out_ranks)
         )

--- a/flowjax/tasks.py
+++ b/flowjax/tasks.py
@@ -33,7 +33,6 @@ class GaussianMixtureSimulator:
     """
 
     def __init__(self, dim: int = 2, prior_bound: float = 10.0) -> None:
-        """Initialize the task."""
         self.dim = dim
         self.prior_bound = prior_bound
         self.prior = Uniform(-jnp.full(dim, prior_bound), jnp.full(dim, prior_bound))

--- a/flowjax/train/data_fit.py
+++ b/flowjax/train/data_fit.py
@@ -23,6 +23,7 @@ PyTree = Any
 
 def fit_to_data(
     key: Array,
+    *,
     dist: PyTree,
     x: ArrayLike,
     condition: ArrayLike = None,

--- a/flowjax/train/data_fit.py
+++ b/flowjax/train/data_fit.py
@@ -23,9 +23,9 @@ PyTree = Any
 
 def fit_to_data(
     key: Array,
-    *,
     dist: PyTree,
     x: ArrayLike,
+    *,
     condition: ArrayLike = None,
     loss_fn: Callable | None = None,
     max_epochs: int = 100,

--- a/flowjax/train/losses.py
+++ b/flowjax/train/losses.py
@@ -106,6 +106,7 @@ class ElboLoss:
         self,
         target: Callable[[ArrayLike], Array],
         num_samples: int,
+        *,
         stick_the_landing: bool = False,
     ):
         """Initialize the ELBO loss.

--- a/flowjax/train/losses.py
+++ b/flowjax/train/losses.py
@@ -50,17 +50,14 @@ class ContrastiveLoss:
         - https://arxiv.org/abs/1905.07488
         - https://arxiv.org/abs/2002.03712
 
+    Args:
+        prior (AbstractDistribution): The prior distribution over x (the target
+            variable).
+        n_contrastive (int): The number of contrastive samples/atoms to use when
+            computing the loss.
     """
 
     def __init__(self, prior: AbstractDistribution, n_contrastive: int):
-        """Initialize the loss function.
-
-        Args:
-            prior (AbstractDistribution): The prior distribution over x (the target
-                variable).
-            n_contrastive (int): The number of contrastive samples/atoms to use when
-                computing the loss.
-        """
         self.prior = prior
         self.n_contrastive = n_contrastive
 
@@ -96,7 +93,21 @@ class ContrastiveLoss:
 
 
 class ElboLoss:
-    """The negative evidence lower bound (ELBO), approximated using samples."""
+    """The negative evidence lower bound (ELBO), approximated using samples.
+
+    Args:
+        num_samples (int): Number of samples to use in the ELBO approximation.
+        target (Callable[[ArrayLike], Array]): The target, i.e. log posterior
+            density up to an additive constant / the negative of the potential
+            function, evaluated for a single point.
+        stick_the_landing (bool): Whether to use the (often) lower variance ELBO
+            gradient estimator introduced in https://arxiv.org/pdf/1703.09194.pdf.
+            Note for flows this requires evaluating the flow in both directions
+            (running the forward and inverse transformation). For some flow
+            architectures, this may be computationally expensive due to assymetrical
+            computational complexity between the forward and inverse transformation.
+            Defaults to False.
+    """
 
     target: Callable[[ArrayLike], Array]
     num_samples: int
@@ -109,21 +120,6 @@ class ElboLoss:
         *,
         stick_the_landing: bool = False,
     ):
-        """Initialize the ELBO loss.
-
-        Args:
-            num_samples (int): Number of samples to use in the ELBO approximation.
-            target (Callable[[ArrayLike], Array]): The target, i.e. log posterior
-                density up to an additive constant / the negative of the potential
-                function, evaluated for a single point.
-            stick_the_landing (bool): Whether to use the (often) lower variance ELBO
-                gradient estimator introduced in https://arxiv.org/pdf/1703.09194.pdf.
-                Note for flows this requires evaluating the flow in both directions
-                (running the forward and inverse transformation). For some flow
-                architectures, this may be computationally expensive due to assymetrical
-                computational complexity between the forward and inverse transformation.
-                Defaults to False.
-        """
         self.target = target
         self.num_samples = num_samples
         self.stick_the_landing = stick_the_landing

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -16,6 +16,7 @@ PyTree = Any
 
 def fit_to_variational_target(
     key: Array,
+    *,
     dist: AbstractDistribution,
     loss_fn: Callable,
     steps: int = 100,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ pythonpath = ["."]
 [tool.ruff]
 select = ["E", "F", "B", "D", "COM", "I", "UP", "TRY004", "RET", "PT"]
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
-ignore = ["D102", "D105"]                                              # Ignore due to trigerring on inherited docstrings
+ignore = ["D102", "D105", "D107"]
 
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ pythonpath = ["."]
 
 
 [tool.ruff]
-select = ["E", "F", "B", "D", "COM", "I", "UP", "TRY004", "RET", "PT"]
+select = ["E", "F", "B", "D", "COM", "I", "UP", "TRY004", "RET", "PT", "FBT"]
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
 ignore = ["D102", "D105", "D107"]
 

--- a/tests/test_bijections/test_bijections.py
+++ b/tests/test_bijections/test_bijections.py
@@ -74,7 +74,7 @@ bijections = {
     "RationalQuadraticSpline": RationalQuadraticSpline(knots=4, interval=1),
     "Coupling (unconditional)": Coupling(
         KEY,
-        Affine(),
+        transformer=Affine(),
         untransformed_dim=DIM // 2,
         dim=DIM,
         cond_dim=None,
@@ -83,7 +83,7 @@ bijections = {
     ),
     "Coupling (conditional)": Coupling(
         KEY,
-        Affine(),
+        transformer=Affine(),
         untransformed_dim=DIM // 2,
         dim=DIM,
         cond_dim=COND_DIM,
@@ -92,7 +92,7 @@ bijections = {
     ),
     "MaskedAutoregressive_Affine (unconditional)": MaskedAutoregressive(
         KEY,
-        Affine(),
+        transformer=Affine(),
         cond_dim=0,
         dim=DIM,
         nn_width=5,
@@ -100,7 +100,7 @@ bijections = {
     ),
     "MaskedAutoregressive_Affine (conditional)": MaskedAutoregressive(
         KEY,
-        Affine(),
+        transformer=Affine(),
         cond_dim=COND_DIM,
         dim=DIM,
         nn_width=5,
@@ -108,7 +108,7 @@ bijections = {
     ),
     "MaskedAutoregressiveRationalQuadraticSpline (unconditional)": MaskedAutoregressive(
         KEY,
-        RationalQuadraticSpline(5, 3),
+        transformer=RationalQuadraticSpline(knots=5, interval=3),
         dim=DIM,
         cond_dim=0,
         nn_width=10,
@@ -157,12 +157,12 @@ bijections = {
     ),
     "Planar": Planar(
         KEY,
-        DIM,
+        dim=DIM,
     ),
     "Vmap (broadcast params)": Vmap(Affine(1, 2), axis_size=10),
     "Vmap (vectorize params)": Vmap(
         eqx.filter_vmap(Affine)(jnp.ones(3)),
-        eqx.if_array(0),
+        in_axis=eqx.if_array(0),
     ),
 }
 

--- a/tests/test_bijections/test_bijections.py
+++ b/tests/test_bijections/test_bijections.py
@@ -1,4 +1,6 @@
 "General tests for bijections (including transformers)."
+from abc import abstractmethod
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -6,6 +8,7 @@ import jax.random as jr
 import pytest
 
 from flowjax.bijections import (
+    AbstractBijection,
     AdditiveCondition,
     Affine,
     BlockAutoregressiveNetwork,
@@ -215,3 +218,74 @@ def test_transform_inverse_and_log_dets(bijection):
 
     except NotImplementedError:
         pass
+
+
+class _AstractTestBijection(AbstractBijection):
+    shape: tuple[int, ...] = ()
+    cond_shape: tuple[int, ...] | None = None
+
+    def transform(self, x, condition=None):
+        return x
+
+    def transform_and_log_det(self, x, condition=None):
+        return x, jnp.zeros(())
+
+    @abstractmethod
+    def inverse(self, y, condition=None):
+        pass
+
+    @abstractmethod
+    def inverse_and_log_det(self, y, condition=None):
+        return y, jnp.zeros(())
+
+
+class _TestBijection(_AstractTestBijection):
+    # Test bijection (with inheritance + method overide)
+    def transform(self, x, condition=None):  # Check overiding
+        return x
+
+    def inverse(self, y, condition=None):
+        return y
+
+    def inverse_and_log_det(self, y, condition=None):
+        return y, jnp.zeros(())
+
+
+test_cases = {
+    "wrong x shape": (
+        [(), None],
+        [jnp.ones(2), None],
+        "Expected input shape",
+    ),
+    "wrong condition shape": (
+        [(), (2,)],
+        [1, jnp.ones(3)],
+        "Expected condition.shape",
+    ),
+    "missing condition": (
+        [(), (2,)],
+        [1, None],
+        "Expected condition to be provided.",
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    ("args", "inputs", "match"),
+    test_cases.values(),
+    ids=test_cases.keys(),
+)
+def test_argcheck(args, inputs, match):
+    bijection = _TestBijection(*args)
+
+    with pytest.raises(ValueError, match=match):
+        bijection.transform(*inputs)
+
+    with pytest.raises(ValueError, match=match):
+        bijection.inverse(*inputs)
+
+    with pytest.raises(ValueError, match=match):
+        bijection.transform_and_log_det(*inputs)
+
+    with pytest.raises(ValueError, match=match):
+        bijection.inverse_and_log_det(*inputs)

--- a/tests/test_bijections/test_bnaf.py
+++ b/tests/test_bijections/test_bnaf.py
@@ -11,7 +11,7 @@ def test_BlockAutoregressiveNetwork():
     x = jnp.ones(dim)
     key = random.PRNGKey(0)
 
-    barn = BlockAutoregressiveNetwork(key, dim, None, depth=1, block_dim=4)
+    barn = BlockAutoregressiveNetwork(key, dim=dim, cond_dim=None, depth=1, block_dim=4)
     y = barn.transform(x)
     assert y.shape == (dim,)
     auto_jacobian = jax.jacobian(barn.transform)(x)
@@ -26,7 +26,9 @@ def test_BlockAutoregressiveNetwork_conditioning():
     cond_dim = 2
     x = jnp.ones(dim)
     key = random.PRNGKey(0)
-    barn = BlockAutoregressiveNetwork(key, dim, cond_dim, depth=1, block_dim=4)
+    barn = BlockAutoregressiveNetwork(
+        key, dim=dim, cond_dim=cond_dim, depth=1, block_dim=4
+    )
     y1 = barn.transform(x, jnp.ones(cond_dim))
     y2 = barn.transform(x, jnp.zeros(cond_dim))
     assert jnp.all(y1 != y2)

--- a/tests/test_bijections/test_jax_transforms.py
+++ b/tests/test_bijections/test_jax_transforms.py
@@ -27,7 +27,7 @@ def test_vmap_uneven_init():
 def test_vmap_condition_only():
     bijection = MaskedAutoregressive(
         jr.PRNGKey(0),
-        Affine(),
+        transformer=Affine(),
         dim=3,
         cond_dim=4,
         nn_width=10,

--- a/tests/test_bijections/test_nn.py
+++ b/tests/test_bijections/test_nn.py
@@ -10,7 +10,9 @@ from flowjax.nn import AutoregressiveMLP, BlockAutoregressiveLinear, MaskedLinea
 
 def test_BlockAutoregressiveLinear():
     block_shape = (3, 2)
-    layer = BlockAutoregressiveLinear(jax.random.PRNGKey(0), 3, block_shape)
+    layer = BlockAutoregressiveLinear(
+        jax.random.PRNGKey(0), n_blocks=3, block_shape=block_shape
+    )
     x = jnp.ones(6)
     a, log_jac_3d = layer(x)
     assert log_jac_3d.shape == (3, *block_shape)

--- a/tests/test_bijections/test_rational_quadratic_spline.py
+++ b/tests/test_bijections/test_rational_quadratic_spline.py
@@ -37,5 +37,5 @@ def test_RationalQuadraticSpline_init():
         spline,
         jr.normal(key, shape),
     )
-    y = spline.transform(x)
+    y = vmap(spline.transform)(x)
     assert pytest.approx(x, abs=1e-6) != y

--- a/tests/test_bijections/test_rational_quadratic_spline.py
+++ b/tests/test_bijections/test_rational_quadratic_spline.py
@@ -24,7 +24,7 @@ def test_RationalQuadraticSpline_tails():
 
 
 def test_RationalQuadraticSpline_init():
-    # Test it is initialised at the identity
+    # Test it is initialized at the identity
     x = jnp.array([-1, 0.1, 2, 1])
     key = jr.PRNGKey(0)
     spline = RationalQuadraticSpline(knots=10, interval=3)

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Callable
 from typing import NamedTuple
 

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -24,7 +24,7 @@ testcases = {
     "triangular_spline_flow": triangular_spline_flow(**KWARGS),
     "Affine_Coupling": coupling_flow(transformer=Affine(), **KWARGS),
     "Spline_Coupling": coupling_flow(
-        transformer=RationalQuadraticSpline(3, 2),
+        transformer=RationalQuadraticSpline(knots=3, interval=2),
         **KWARGS,
     ),
     "Affine_MaskedAutoregessive": masked_autoregressive_flow(
@@ -54,7 +54,7 @@ conditional_testcases = {
     "triangular_spline_flow": triangular_spline_flow(**KWARGS, cond_dim=2),
     "Affine_Coupling": coupling_flow(transformer=Affine(), **KWARGS, cond_dim=2),
     "Spline_Coupling": coupling_flow(
-        transformer=RationalQuadraticSpline(3, 2),
+        transformer=RationalQuadraticSpline(knots=3, interval=2),
         **KWARGS,
         cond_dim=2,
     ),

--- a/tests/train/test_data_fit.py
+++ b/tests/train/test_data_fit.py
@@ -17,7 +17,9 @@ def test_data_fit_filter_spec():
     # All params should change by default
     before = eqx.filter(flow, eqx.is_inexact_array)
     x = random.normal(random.PRNGKey(0), (100, dim))
-    flow, _ = fit_to_data(random.PRNGKey(0), flow, x, max_epochs=1, batch_size=50)
+    flow, _ = fit_to_data(
+        random.PRNGKey(0), dist=flow, x=x, max_epochs=1, batch_size=50
+    )
     after = eqx.filter(flow, eqx.is_inexact_array)
 
     assert jnp.all(before.base_dist.bijection.loc != after.base_dist.bijection.loc)


### PR DESCRIPTION
Breaking changes:

**Distribution API**
- We remove  ``AbstractStandardDistribution``, and instead add a default ``_sample_and_log_prob`` to ``AbstractDistribution``, and override this in ``AbstractTransformed``.
- Downside: this breaks the "abstract final" pattern (as we make use of a method override). Upside: avoids need for ``AbstractStandardDistribution`` which, deepens the class hierarchy solely to define a default implementation for one method.

**Bijection API**
- Bijections now have an ``__init_subclass__`` method, which automatically adds argument checking and casting of arguments to arrays in bijection methods, removing the need for e.g. `` x, _ = self._argcheck_and_cast(x)``. This method has been removed as it is no longer needed.

**Key word only arguments**
- A lot of functions and classes now make use of key word only arguments to ensure more readable code (e.g. as  ``TriangularAffine(loc, arr, lower=True)`` is much clearer than ``TriangularAffine(loc, arr, True)``.
- This may introduce errors along the lines of "TypeError: function takes at most ... arguments (... given)", but it is generally straight forward to fix this using key word arguments.


