### PR TITLE
Add distribution_to_numpyro

### DIFF
--- a/docs/api/experimental.rst
+++ b/docs/api/experimental.rst
@@ -17,10 +17,9 @@ in its infancy and there may be breaking changes without warning.
     
 In general, we can use a combination of flowjax and numpyro distributions in a
 numpyro model by using :func:`~flowjax.experimental.numpyro.sample`, in place of
-numpyro's ``sample``. This will wrap flowjax
-:class:`~flowjax.distributions.AbstractTransformed` distributions to numpyro
-distributions, using :class:`~flowjax.experimental.numpyro.TransformedToNumpyro`.
-This can be used for example to embed normalising flows into arbitrary
+numpyro's ``sample``. This will wrap flowjax distributions to numpyro
+distributions, using :func:`~flowjax.experimental.numpyro.distribution_to_numpyro`.
+This approach can be used for example to embed normalising flows into arbitrary
 probabilistic models. Here is a simple example
 
     .. doctest::

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -11,8 +11,9 @@ from typing import Any
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jax.typing import ArrayLike
 from jax import Array
+from jax.typing import ArrayLike
+
 from flowjax.utils import arraylike_to_array
 
 try:
@@ -25,8 +26,9 @@ except ImportError as e:
     raise
 
 from numpyro.distributions import constraints
+
 from flowjax.bijections import AbstractBijection
-from flowjax.distributions import AbstractTransformed, AbstractDistribution
+from flowjax.distributions import AbstractDistribution, AbstractTransformed
 from flowjax.utils import _get_ufunc_signature
 
 PyTree = Any
@@ -48,7 +50,6 @@ def sample(name: str, fn: Any, *args, condition=None, **kwargs):
         *args: Passed to numpyro sample.
         **kwargs: Passed to numpyro sample.
     """
-
     if isinstance(fn, AbstractDistribution):
         fn = distribution_to_numpyro(fn, condition)
 
@@ -80,7 +81,8 @@ def register_params(
 
 
 def distribution_to_numpyro(
-    dist: AbstractDistribution, condition: ArrayLike | None = None
+    dist: AbstractDistribution,
+    condition: ArrayLike | None = None,
 ):
     """Convert a flowjax distribution to a numpyro distribution.
 
@@ -90,7 +92,6 @@ def distribution_to_numpyro(
             be converted to batch dimensions in the numpyro distribution. Defaults to
             None.
     """
-
     if isinstance(dist, AbstractTransformed):
         return _TransformedToNumpyro(dist, condition)
     return _DistributionToNumpyro(dist, condition)
@@ -211,6 +212,5 @@ def _get_batch_shape(condition, cond_shape):
     if condition is not None:
         if len(cond_shape) > 0:
             return condition.shape[: -len(cond_shape)]
-        else:
-            return condition.shape
+        return condition.shape
     return ()

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -12,7 +12,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jax.typing import ArrayLike
-
+from jax import Array
 from flowjax.utils import arraylike_to_array
 
 try:
@@ -26,15 +26,145 @@ except ImportError as e:
 
 from numpyro.distributions import constraints
 from flowjax.bijections import AbstractBijection
-from flowjax.distributions import AbstractTransformed
+from flowjax.distributions import AbstractTransformed, AbstractDistribution
 from flowjax.utils import _get_ufunc_signature
 
 PyTree = Any
 # TODO list:
 #    - How to add support of batch dimensions.
-#    - Do I need to support non-transformed distributions?
 #    - Allow control of supports and constraints - will applications of transformations
 #           to apply constraints lead to problems with reparameterisation?
+
+
+def sample(name: str, fn: Any, *args, condition=None, **kwargs):
+    """Numpyro sample wrapper that wraps flowjax distributions.
+
+    Args:
+        name: Name of the sample site.
+        fn: A flowjax distribution, numpyro distribution or a stochastic function that
+            returns a sample.
+        condition: Conditioning variable if fn is a conditional flowjax distribution.
+            Defaults to None.
+        *args: Passed to numpyro sample.
+        **kwargs: Passed to numpyro sample.
+    """
+
+    if isinstance(fn, AbstractDistribution):
+        fn = distribution_to_numpyro(fn, condition)
+
+    return numpyro.sample(name, fn, *args, **kwargs)
+
+
+def register_params(
+    name: str,
+    model: PyTree,
+    filter_spec: Callable | PyTree = eqx.is_inexact_array,
+):
+    """Register numpyro params for an arbitrary pytree.
+
+    This partitions the parameters and static components, registers the parameters using
+    numpyro.param, then recombines them. This should be called from within an inference
+    context to have an effect, e.g. within a numpyro model or guide function.
+
+    Args:
+        name: Name for the parameter set.
+        model: The pytree (e.g. an equinox module, flowjax distribution/bijection).
+        filter_spec: Equinox `filter_spec` for specifying trainable parameters. Either a
+            callable `leaf -> bool`, or a PyTree with prefix structure matching `dist`
+            with True/False values. Defaults to `eqx.is_inexact_array`.
+
+    """
+    params, static = eqx.partition(model, filter_spec)
+    params = numpyro.param(name, params)
+    return eqx.combine(params, static)
+
+
+def distribution_to_numpyro(
+    dist: AbstractDistribution, condition: ArrayLike | None = None
+):
+    """Convert a flowjax distribution to a numpyro distribution.
+
+    Args:
+        dist (AbstractDistribution): Flowjax distribution
+        condition: condition: Conditioning variables. Any leading batch dimensions will
+            be converted to batch dimensions in the numpyro distribution. Defaults to
+            None.
+    """
+
+    if isinstance(dist, AbstractTransformed):
+        return _TransformedToNumpyro(dist, condition)
+    return _DistributionToNumpyro(dist, condition)
+
+
+class _DistributionToNumpyro(numpyro.distributions.Distribution):
+    dist: AbstractDistribution
+    _condition: Array
+
+    def __init__(
+        self,
+        dist: AbstractDistribution,
+        condition: ArrayLike | None = None,
+    ):
+        self.dist = dist
+
+        if condition is not None:
+            condition = arraylike_to_array(condition, "condition")
+        self._condition = condition
+        self.support = constraints.real
+        batch_shape = _get_batch_shape(condition, dist.cond_shape)
+        super().__init__(batch_shape=batch_shape, event_shape=dist.shape)
+
+    @property
+    def condition(self):
+        return jax.lax.stop_gradient(self._condition)
+
+    def sample(self, key, sample_shape=...):
+        return self.dist.sample(key, sample_shape, self.condition)
+
+    def log_prob(self, value):
+        return self.dist.log_prob(value, self.condition)
+
+
+class _TransformedToNumpyro(numpyro.distributions.Distribution):
+    def __init__(
+        self,
+        dist: AbstractTransformed,
+        condition: ArrayLike | None = None,
+    ):
+        self.dist = dist.merge_transforms()  # Ensure base distribution not transformed
+        if condition is not None:
+            condition = arraylike_to_array(condition, "condition")
+        self._condition = condition
+        self.support = constraints.real
+        batch_shape = _get_batch_shape(condition, dist.cond_shape)
+        super().__init__(batch_shape=batch_shape, event_shape=dist.shape)
+
+    @property
+    def condition(self):
+        return jax.lax.stop_gradient(self._condition)
+
+    def sample(self, key, sample_shape=...):
+        return self.dist.sample(key, sample_shape, self.condition)
+
+    def sample_with_intermediates(self, key, sample_shape=...):
+        # Sample the distribution returning the base distribution sample.
+        z = self.dist.base_dist.sample(key, sample_shape, self._base_condition)
+        x = _VectorizedBijection(self.dist.bijection).transform(z, self.condition)
+        return x, [z]
+
+    def log_prob(self, value, intermediates=None):
+        if intermediates is None:
+            return self.dist.log_prob(value, self.condition)
+
+        z = intermediates[0]
+        _, log_det = _VectorizedBijection(
+            self.dist.bijection,
+        ).transform_and_log_det(z, self.condition)
+        return self.dist.base_dist.log_prob(z, self._base_condition) - log_det
+
+    @property
+    def _base_condition(self):
+        return self.condition if self.dist.base_dist.cond_shape else None
 
 
 class _VectorizedBijection:
@@ -77,104 +207,10 @@ class _VectorizedBijection:
         return jnp.vectorize(func, signature=sig, excluded=exclude)
 
 
-class TransformedToNumpyro(numpyro.distributions.Distribution):
-    """Convert a flowjax transformed distribution to a numpyro distribution.
-
-    We assume the support of the distribution is unbounded.
-
-    Args:
-        dist: The flowjax distribution.
-        condition: Conditioning variables. Any leading batch dimensions will be
-            converted to batch dimensions in the numpyro distribution. Defaults to None.
-    """
-
-    def __init__(
-        self,
-        dist: AbstractTransformed,
-        condition: ArrayLike | None = None,
-    ):
-        if condition is not None:
-            condition = arraylike_to_array(condition, "condition")
-            batch_shape = (
-                condition.shape[: -len(dist.cond_shape)] if dist.cond_ndim > 0 else ()
-            )
+def _get_batch_shape(condition, cond_shape):
+    if condition is not None:
+        if len(cond_shape) > 0:
+            return condition.shape[: -len(cond_shape)]
         else:
-            batch_shape = ()
-
-        self.dist = dist.merge_transforms()  # Ensure base distribution not transformed
-        self._condition = condition
-        self.support = constraints.real
-        super().__init__(batch_shape=batch_shape, event_shape=dist.shape)
-
-    def sample(self, key, sample_shape=...):
-        """Sample the distribution."""
-        return self.dist.sample(key, sample_shape, self.condition)
-
-    def sample_with_intermediates(self, key, sample_shape=...):
-        """Sample the distribution returning the base distribution sample."""
-        z = self.dist.base_dist.sample(key, sample_shape, self._base_condition)
-        x = _VectorizedBijection(self.dist.bijection).transform(z, self.condition)
-        return x, [z]
-
-    def log_prob(self, value, intermediates=None):
-        """Compute the log probabilities."""
-        if intermediates is None:
-            return self.dist.log_prob(value, self.condition)
-
-        z = intermediates[0]
-        _, log_det = _VectorizedBijection(
-            self.dist.bijection,
-        ).transform_and_log_det(z, self.condition)
-        return self.dist.base_dist.log_prob(z, self._base_condition) - log_det
-
-    @property
-    def condition(self):
-        """condition, wrapped with stop gradient to avoid training."""
-        return jax.lax.stop_gradient(self._condition)
-
-    @property
-    def _base_condition(self):
-        return self.condition if self.dist.base_dist.cond_shape else None
-
-
-def sample(name: str, fn: Any, *args, condition=None, **kwargs):
-    """Numpyro sample wrapper that wraps flowjax AbstractTransformed distributions.
-
-    Args:
-        name: Name of the sample site.
-        fn: A flowjax distribution, numpyro distribution or a stochastic function that
-            returns a sample.
-        condition: Conditioning variable if fn is a conditional flowjax distribution.
-            Defaults to None.
-        *args: Passed to numpyro sample.
-        **kwargs: Passed to numpyro sample.
-    """
-
-    if isinstance(fn, AbstractTransformed):
-        fn = TransformedToNumpyro(fn, condition)
-
-    return numpyro.sample(name, fn, *args, **kwargs)
-
-
-def register_params(
-    name: str,
-    model: PyTree,
-    filter_spec: Callable | PyTree = eqx.is_inexact_array,
-):
-    """Register numpyro params for an arbitrary pytree.
-
-    This partitions the parameters and static components, registers the parameters using
-    numpyro.param, then recombines them. This should be called from within an inference
-    context to have an effect, e.g. within a numpyro model or guide function.
-
-    Args:
-        name: Name for the parameter set.
-        model: The pytree (e.g. an equinox module, flowjax distribution/bijection).
-        filter_spec: Equinox `filter_spec` for specifying trainable parameters. Either a
-            callable `leaf -> bool`, or a PyTree with prefix structure matching `dist`
-            with True/False values. Defaults to `eqx.is_inexact_array`.
-
-    """
-    params, static = eqx.partition(model, filter_spec)
-    params = numpyro.param(name, params)
-    return eqx.combine(params, static)
+            return condition.shape
+    return ()

--- a/tests/test_experimental/test_numpyro.py
+++ b/tests/test_experimental/test_numpyro.py
@@ -8,16 +8,16 @@ import numpyro.distributions as ndist
 import pytest
 from equinox.nn import Linear
 from jax.flatten_util import ravel_pytree
-from flowjax.experimental.numpyro import sample
 from numpyro.infer import MCMC, NUTS, SVI, Trace_ELBO
 from numpyro.optim import Adam
 
 from flowjax.bijections import AdditiveCondition
 from flowjax.distributions import Normal, StandardNormal, Transformed
 from flowjax.experimental.numpyro import (
+    _get_batch_shape,
     distribution_to_numpyro,
     register_params,
-    _get_batch_shape,
+    sample,
 )
 from flowjax.flows import block_neural_autoregressive_flow
 

--- a/tests/test_experimental/test_numpyro.py
+++ b/tests/test_experimental/test_numpyro.py
@@ -14,7 +14,11 @@ from numpyro.optim import Adam
 
 from flowjax.bijections import AdditiveCondition
 from flowjax.distributions import Normal, StandardNormal, Transformed
-from flowjax.experimental.numpyro import TransformedToNumpyro, register_params
+from flowjax.experimental.numpyro import (
+    distribution_to_numpyro,
+    register_params,
+    _get_batch_shape,
+)
 from flowjax.flows import block_neural_autoregressive_flow
 
 true_mean, true_std = jnp.ones(2), 2 * jnp.ones(2)
@@ -22,6 +26,12 @@ true_mean, true_std = jnp.ones(2), 2 * jnp.ones(2)
 
 def numpyro_model():
     sample("x", Normal(true_mean, true_std))
+
+
+def test_get_batch_shape():
+    assert _get_batch_shape(jnp.ones((2, 3)), ()) == (2, 3)
+    assert _get_batch_shape(jnp.ones(3), (3,)) == ()
+    assert _get_batch_shape(jnp.ones((1, 2, 3)), (2, 3)) == (1,)
 
 
 def test_mcmc():
@@ -143,26 +153,28 @@ def test_vi_plate():
 
 
 key = jr.PRNGKey(0)
-test_cases = [[(), ()], [(2,), ()], [(), (2,)], [(3, 2, 4), (1, 2)]]
+test_cases = {
+    "distribution": [
+        StandardNormal(()),
+        StandardNormal((1, 2)),
+        Normal(),
+        Normal(jnp.ones((1, 2))),
+    ],
+    "sample_shape": [(), (3, 4)],
+}
 
 
-@pytest.mark.parametrize(("shape", "sample_shape"), test_cases)
-def test_TransformedToNumpyro(shape, sample_shape):
-    key, subkey = jr.split(jr.PRNGKey(0))
-    means = jr.normal(subkey, shape)
-
-    key, subkey = jr.split(key)
-    stds = jnp.exp(jr.normal(subkey, shape))
-
-    dist = Normal(means, stds)
-    wrapped = TransformedToNumpyro(dist)
+@pytest.mark.parametrize("distribution", test_cases["distribution"])
+@pytest.mark.parametrize("sample_shape", test_cases["sample_shape"])
+def test_distribution_to_numpyro(distribution, sample_shape):
+    wrapped = distribution_to_numpyro(distribution)
 
     # Same key should lead to same samples
-    x = dist.sample(key, sample_shape)
+    x = distribution.sample(key, sample_shape)
     assert wrapped.sample(key, sample_shape) == pytest.approx(x)
 
     # Should give same log prob
-    assert wrapped.log_prob(x) == pytest.approx(dist.log_prob(x))
+    assert wrapped.log_prob(x) == pytest.approx(distribution.log_prob(x))
 
 
 def test_batched_condition():
@@ -176,7 +188,7 @@ def test_batched_condition():
     )
 
     condition = jnp.ones((10, 3))
-    wrapped = TransformedToNumpyro(dist, condition)
+    wrapped = distribution_to_numpyro(dist, condition)
     assert wrapped.batch_shape == (10,)
 
     key, subkey = jr.split(key)


### PR DESCRIPTION
In general, distribution_to_numpyro now replaces TransformedToNumpyro, and now supports non-transformed distributions.