### PR TITLE
Numpyro conditional bug fix

### DIFF
--- a/flowjax/bijections/block_autoregressive_network.py
+++ b/flowjax/bijections/block_autoregressive_network.py
@@ -1,12 +1,12 @@
 """Block Neural Autoregressive bijection implementation."""
+
 from collections.abc import Callable
 from typing import ClassVar
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jax import random
-from jax.random import KeyArray
+from jax import Array, random
 
 from flowjax.bijections.bijection import AbstractBijection
 from flowjax.bijections.tanh import LeakyTanh
@@ -66,6 +66,7 @@ class BlockAutoregressiveNetwork(AbstractBijection):
             ``inverter(bijection, y, condition=None)``. Defaults to
             ``AutoregressiveBisectionInverter``.
     """
+
     shape: tuple[int, ...]
     cond_shape: tuple[int, ...] | None
     depth: int
@@ -76,7 +77,7 @@ class BlockAutoregressiveNetwork(AbstractBijection):
 
     def __init__(
         self,
-        key: KeyArray,
+        key: Array,
         *,
         dim: int,
         cond_dim: int | None,

--- a/flowjax/bijections/coupling.py
+++ b/flowjax/bijections/coupling.py
@@ -2,12 +2,12 @@
 
 Ref: https://arxiv.org/abs/1605.08803.
 """
+
 from collections.abc import Callable
 
 import equinox as eqx
 import jax.nn as jnn
 import jax.numpy as jnp
-from jax.random import KeyArray
 
 from flowjax.bijections.bijection import AbstractBijection
 from flowjax.bijections.jax_transforms import Vmap
@@ -38,7 +38,7 @@ class Coupling(AbstractBijection):
 
     def __init__(
         self,
-        key: KeyArray,
+        key: Array,
         *,
         transformer: AbstractBijection,
         untransformed_dim: int,
@@ -68,9 +68,9 @@ class Coupling(AbstractBijection):
         )
 
         conditioner = eqx.nn.MLP(
-            in_size=untransformed_dim
-            if cond_dim is None
-            else untransformed_dim + cond_dim,
+            in_size=(
+                untransformed_dim if cond_dim is None else untransformed_dim + cond_dim
+            ),
             out_size=conditioner_output_size,
             width_size=nn_width,
             depth=nn_depth,

--- a/flowjax/bijections/exp.py
+++ b/flowjax/bijections/exp.py
@@ -1,4 +1,5 @@
 """Exponential bijection."""
+
 from typing import ClassVar
 
 import jax.numpy as jnp

--- a/flowjax/bijections/masked_autoregressive.py
+++ b/flowjax/bijections/masked_autoregressive.py
@@ -8,7 +8,6 @@ import jax
 import jax.nn as jnn
 import jax.numpy as jnp
 from jax import Array
-from jax.random import KeyArray
 
 from flowjax.bijections.bijection import AbstractBijection
 from flowjax.bijections.jax_transforms import Vmap
@@ -44,7 +43,7 @@ class MaskedAutoregressive(AbstractBijection):
 
     def __init__(
         self,
-        key: KeyArray,
+        key: Array,
         *,
         transformer: AbstractBijection,
         dim: int,

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -137,7 +137,7 @@ class _TransformedToNumpyro(numpyro.distributions.Distribution):
     ):
         self.dist = dist.merge_transforms()  # Ensure base distribution not transformed
 
-        if dist.base_dist.cond_shape is not None:
+        if self.dist.base_dist.cond_shape is not None:
             raise ValueError("Conditional base distributions are not yet supported.")
 
         if condition is not None:

--- a/flowjax/experimental/numpyro.py
+++ b/flowjax/experimental/numpyro.py
@@ -3,6 +3,7 @@
 Note these utilities require `numpyro <https://github.com/pyro-ppl/numpyro>`_ to be
 installed.
 """
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -121,7 +122,7 @@ class _DistributionToNumpyro(numpyro.distributions.Distribution):
     def condition(self):
         return jax.lax.stop_gradient(self._condition)
 
-    def sample(self, key, sample_shape=...):
+    def sample(self, key, sample_shape=()):
         return self.dist.sample(key, sample_shape, self.condition)
 
     def log_prob(self, value):
@@ -135,6 +136,10 @@ class _TransformedToNumpyro(numpyro.distributions.Distribution):
         condition: ArrayLike | None = None,
     ):
         self.dist = dist.merge_transforms()  # Ensure base distribution not transformed
+
+        if dist.base_dist.cond_shape is not None:
+            raise ValueError("Conditional base distributions are not yet supported.")
+
         if condition is not None:
             condition = arraylike_to_array(condition, "condition")
         self._condition = condition
@@ -146,14 +151,14 @@ class _TransformedToNumpyro(numpyro.distributions.Distribution):
     def condition(self):
         return jax.lax.stop_gradient(self._condition)
 
-    def sample(self, key, sample_shape=...):
+    def sample(self, key, sample_shape=()):
         return self.dist.sample(key, sample_shape, self.condition)
 
-    def sample_with_intermediates(self, key, sample_shape=...):
-        # Sample the distribution returning the base distribution sample.
-        z = self.dist.base_dist.sample(key, sample_shape, self._base_condition)
+    def sample_with_intermediates(self, key, sample_shape=()):
+        z = self.dist.base_dist.sample(key, sample_shape + self.batch_shape)
         x, log_det = _VectorizedBijection(self.dist.bijection).transform_and_log_det(
-            z, self.condition
+            x=z,
+            condition=self.condition,
         )
         return x, [z, log_det]
 
@@ -162,11 +167,7 @@ class _TransformedToNumpyro(numpyro.distributions.Distribution):
             return self.dist.log_prob(value, self.condition)
 
         z, log_det = intermediates
-        return self.dist.base_dist.log_prob(z, self._base_condition) - log_det
-
-    @property
-    def _base_condition(self):
-        return self.condition if self.dist.base_dist.cond_shape else None
+        return self.dist.base_dist.log_prob(z) - log_det
 
 
 class _VectorizedBijection:
@@ -195,6 +196,13 @@ class _VectorizedBijection:
             log_det=True,
         )
         return transform_and_log_det(x, condition)
+
+    def inverse_and_log_det(self, x, condition=None):
+        inverse_and_log_det = self.vectorize(
+            self.bijection.inverse_and_log_det,
+            log_det=True,
+        )
+        return inverse_and_log_det(x, condition)
 
     def vectorize(self, func, *, log_det=False):
         in_shapes, out_shapes = [self.bijection.shape], [self.bijection.shape]

--- a/flowjax/nn/block_autoregressive.py
+++ b/flowjax/nn/block_autoregressive.py
@@ -1,11 +1,11 @@
 """Block autoregressive neural network components."""
+
 from collections.abc import Callable
 
 import equinox as eqx
 import jax.numpy as jnp
 from jax import Array, random
 from jax.nn.initializers import glorot_uniform
-from jax.random import KeyArray
 
 from flowjax.masks import block_diag_mask, block_tril_mask
 
@@ -39,7 +39,7 @@ class BlockAutoregressiveLinear(eqx.Module):
 
     def __init__(
         self,
-        key: KeyArray,
+        key: Array,
         *,
         n_blocks: int,
         block_shape: tuple,


### PR DESCRIPTION
Fixes bug where when wrapping a flowjax distribution into a numpyro distribution, the base distribution sample shape did not expand appropriately when a batch of conditioning variables was used.