### PR TITLE
Option to control returning best parameters vs last parameters in training

### DIFF
--- a/flowjax/train/data_fit.py
+++ b/flowjax/train/data_fit.py
@@ -1,4 +1,5 @@
 """Function to fit flows to samples from a distribution."""
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -37,6 +38,7 @@ def fit_to_data(
     learning_rate: float = 5e-4,
     optimizer: optax.GradientTransformation | None = None,
     filter_spec: Callable | PyTree = eqx.is_inexact_array,
+    return_best: bool = True,
     show_progress: bool = True,
 ):
     r"""Train a distribution (e.g. a flow) to samples from the target distribution.
@@ -63,6 +65,9 @@ def fit_to_data(
         filter_spec: Equinox `filter_spec` for specifying trainable parameters. Either a
             callable `leaf -> bool`, or a PyTree with prefix structure matching `dist`
             with True/False values. Defaults to `eqx.is_inexact_array`.
+        return_best: Whether the result should use the parameters where the minimum loss
+            was reached (when True), or the parameters after the last update (when
+            False). Defaults to True.
         show_progress: Whether to show progress bar. Defaults to True.
 
     Returns:
@@ -123,5 +128,6 @@ def fit_to_data(
             loop.set_postfix_str(f"{loop.postfix} (Max patience reached)")
             break
 
-    dist = eqx.combine(best_params, static)
+    params = best_params if return_best else params
+    dist = eqx.combine(params, static)
     return dist, losses

--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -1,4 +1,5 @@
 """Basic training script for fitting a flow using variational inference."""
+
 from collections.abc import Callable
 from typing import Any
 
@@ -23,6 +24,7 @@ def fit_to_variational_target(
     learning_rate: float = 5e-4,
     optimizer: optax.GradientTransformation | None = None,
     filter_spec: Callable | PyTree = eqx.is_inexact_array,
+    return_best: bool = True,
     show_progress: bool = True,
 ) -> tuple[AbstractDistribution, list]:
     """Train a distribution (e.g. a flow) by variational inference.
@@ -39,6 +41,9 @@ def fit_to_variational_target(
         filter_spec: Equinox `filter_spec` for specifying trainable parameters. Either
             a callable `leaf -> bool`, or a PyTree with prefix structure matching `dist`
             with True/False values. Defaults to eqx.is_inexact_array.
+        return_best: Whether the result should use the parameters where the minimum loss
+            was reached (when True), or the parameters after the last update (when
+            False). Defaults to True.
         show_progress: Whether to show progress bar. Defaults to True.
 
     Returns:
@@ -68,5 +73,5 @@ def fit_to_variational_target(
         keys.set_postfix({"loss": loss.item()})
         if loss.item() == min(losses):
             best_params = params
-
-    return eqx.combine(best_params, static), losses
+    params = best_params if return_best else params
+    return eqx.combine(params, static), losses


### PR DESCRIPTION
Adds an option to allow returning the last model, rather than the one which led to the minimum loss. Useful e.g. if loss is high variance to ignore spurious low loss values, or for debugging a model that starts returning nans during training.