### PR TITLE
Reshape

### DIFF
--- a/flowjax/bijections/__init__.py
+++ b/flowjax/bijections/__init__.py
@@ -13,7 +13,7 @@ from .planar import Planar
 from .rational_quadratic_spline import RationalQuadraticSpline
 from .softplus import SoftPlus
 from .tanh import LeakyTanh, Tanh
-from .utils import EmbedCondition, Flip, Identity, Invert, Partial, Permute
+from .utils import EmbedCondition, Flip, Identity, Invert, Partial, Permute, Reshape
 
 __all__ = [
     "AdditiveCondition",
@@ -34,6 +34,7 @@ __all__ = [
     "Permute",
     "Planar",
     "RationalQuadraticSpline",
+    "Reshape",
     "Scale",
     "Scan",
     "SoftPlus",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,14 +44,17 @@ pythonpath = ["."]
 
 
 [tool.ruff]
-select = ["E", "F", "B", "D", "COM", "I", "UP", "TRY004", "RET", "PT", "FBT"]
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
+
+[tool.ruff.lint]
+select = ["E", "F", "B", "D", "COM", "I", "UP", "TRY004", "RET", "PT", "FBT"]
 ignore = ["D102", "D105", "D107"]
 
-[tool.ruff.pydocstyle]
+
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D"]
 "*.ipynb" = ["D"]
 "__init__.py" = ["D"]

--- a/tests/test_bijections/test_bijections.py
+++ b/tests/test_bijections/test_bijections.py
@@ -169,7 +169,15 @@ bijections = {
     ),
     "Reshape (unconditional)": Reshape(Affine(scale=jnp.arange(1, 5)), (2, 2)),
     "Reshape (conditional)": Reshape(
-        BlockAutoregressiveNetwork(KEY, dim=DIM, cond_dim=1, block_dim=3, depth=1),
+        MaskedAutoregressive(
+            KEY,
+            transformer=Affine(),
+            dim=4,
+            cond_dim=1,
+            nn_width=3,
+            nn_depth=1,
+        ),
+        shape=(1, 4, 1),
         cond_shape=(),
     ),
 }

--- a/tests/test_bijections/test_bijections.py
+++ b/tests/test_bijections/test_bijections.py
@@ -25,6 +25,7 @@ from flowjax.bijections import (
     Permute,
     Planar,
     RationalQuadraticSpline,
+    Reshape,
     Scale,
     Scan,
     SoftPlus,
@@ -165,6 +166,11 @@ bijections = {
     "Vmap (vectorize params)": Vmap(
         eqx.filter_vmap(Affine)(jnp.ones(3)),
         in_axis=eqx.if_array(0),
+    ),
+    "Reshape (unconditional)": Reshape(Affine(scale=jnp.arange(1, 5)), (2, 2)),
+    "Reshape (conditional)": Reshape(
+        BlockAutoregressiveNetwork(KEY, dim=DIM, cond_dim=1, block_dim=3, depth=1),
+        cond_shape=(),
     ),
 }
 


### PR DESCRIPTION
Add a ``Reshape`` bijection. One use for this is for defining scalar flows, even if the bijections force ``flow.ndim==1`` on construction.