### PR TITLE
min scale for affine transformer

### DIFF
--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -1,4 +1,5 @@
 """Affine bijections."""
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -137,6 +138,7 @@ class TriangularAffine(AbstractBijection):
             from an unbounded domain to the positive domain. Also used for weight
             normalisation parameters, if used. Defaults to SoftPlus.
     """
+
     shape: tuple[int, ...]
     cond_shape: ClassVar[None] = None
     loc: Array


### PR DESCRIPTION
For default Affine transformer, we limit the scale to >1e-2. This seems to improve stability in some cases, and is also done in other implmentations. The previous behaviour can be achieved by passing ``Affine()`` as the transformer (the previous default).