### PR TITLE
Replace jax.tree API with jax.tree_util for backwards compatibility

### DIFF
--- a/flowjax/bijections/jax_transforms.py
+++ b/flowjax/bijections/jax_transforms.py
@@ -94,7 +94,7 @@ def _check_no_unwrappables(pytree):
     def _is_unwrappable(leaf):
         return isinstance(leaf, wrappers.AbstractUnwrappable)
 
-    leaves = jax.tree.leaves(pytree, is_leaf=_is_unwrappable)
+    leaves = tree_leaves(pytree, is_leaf=_is_unwrappable)
     if any(_is_unwrappable(leaf) for leaf in leaves):
         raise ValueError(
             "In axes containing unwrappables is not supported. In axes must be "

--- a/flowjax/wrappers.py
+++ b/flowjax/wrappers.py
@@ -92,7 +92,7 @@ class AbstractUnwrappable(eqx.Module, Generic[T]):
             return v_unwrap(unwrappable)
 
         flat, tree_def = eqx.tree_flatten_one_level(self)
-        tree = jax.tree.unflatten(tree_def, unwrap(flat))
+        tree = jax.tree_util.tree_unflatten(tree_def, unwrap(flat))
         return vectorized_unwrap(tree)
 
     @abstractmethod


### PR DESCRIPTION
This replaces two instances of the new `jax.tree` API with the equivalent `jax.tree_util` functions. The former is only available since `jax==0.4.25`, so the other option would be to include `>=0.4.25` in the dependencies.