### PR TITLE
Fix param, static order in MaximumLikelihoodLoss

### DIFF
--- a/flowjax/train/losses.py
+++ b/flowjax/train/losses.py
@@ -34,7 +34,7 @@ class MaximumLikelihoodLoss:
         condition: Array | None = None,
     ):
         """Compute the loss."""
-        dist = unwrap(eqx.combine(static, params))
+        dist = unwrap(eqx.combine(params, static))
         return -dist.log_prob(x, condition).mean()
 
 


### PR DESCRIPTION
Using ``eqx.combine`` with static first causes problems with ``NonTrainable``, as we get a ``None`` in ``params``, which causes the structures to not match when combining. Briefly, this is because ``eqx.combine(None, [1,1])`` works, and ``eqx.combine([1,1], None)`` is not allowed as the "structures do not match".
