### PR TITLE
Int dummy

### DIFF
--- a/flowjax/wrappers.py
+++ b/flowjax/wrappers.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
 import equinox as eqx
 import jax.numpy as jnp
+from jaxtyping import Int, Scalar
 
 from flowjax.utils import arraylike_to_array
 
@@ -62,16 +63,12 @@ class AbstractUnwrappable(eqx.Module, Generic[T]):
     stop_gradient before accessing the parameters.
 
     If ``_dummy`` is set to an array (must have shape ()), this is used for inferring
-    vmapped dimensions (and sizes) when unwrapping to automatically vecotorize the
-    method. In some cases this is important for supporting the case where an
+    vmapped dimensions (and sizes) when calling ``unwrap`` to automatically vecotorize
+    the method. In some cases this is important for supporting the case where an
     ``AbstractUnwrappable`` is created within e.g. ``eqx.filter_vmap``.
     """
 
-    _dummy: eqx.AbstractVar[Array | None]
-
-    def __check_init__(self):
-        if self._dummy is not None and self._dummy.shape != ():
-            raise ValueError("_dummy should be initialized with shape ().")
+    _dummy: eqx.AbstractVar[Int[Scalar, ""] | None]
 
     def recursive_unwrap(self) -> T:
         """Returns the unwrapped pytree, unwrapping subnodes as required."""
@@ -140,7 +137,7 @@ class BijectionReparam(AbstractUnwrappable[Array]):
 
     arr: Array | AbstractUnwrappable[Array]
     bijection: "AbstractBijection"
-    _dummy: Array
+    _dummy: Int[Scalar, ""]
 
     def __init__(
         self,
@@ -156,7 +153,7 @@ class BijectionReparam(AbstractUnwrappable[Array]):
                 arr = arraylike_to_array(arr)
             self.arr = arr
         self.bijection = bijection
-        self._dummy = jnp.empty(())
+        self._dummy = jnp.empty((), int)
 
     def unwrap(self) -> Array:
         return self.bijection._vectorize.transform(self.arr)
@@ -216,13 +213,13 @@ class Lambda(AbstractUnwrappable[T]):
     fn: Callable[..., T]
     args: Iterable
     kwargs: dict
-    _dummy: Array
+    _dummy: Int[Scalar, ""]
 
     def __init__(self, fn, *args, **kwargs):
         self.fn = fn
         self.args = args
         self.kwargs = kwargs
-        self._dummy = jnp.empty(())
+        self._dummy = jnp.empty((), int)
 
     def unwrap(self) -> T:
         return self.fn(*self.args, **self.kwargs)

--- a/flowjax/wrappers.py
+++ b/flowjax/wrappers.py
@@ -80,7 +80,7 @@ class AbstractUnwrappable(eqx.Module, Generic[T]):
             def v_unwrap(unwrappable):
                 return unwrappable.unwrap()
 
-            for dim in unwrappable._dummy.shape:
+            for dim in reversed(unwrappable._dummy.shape):
                 v_unwrap = eqx.filter_vmap(v_unwrap, axis_size=dim)
             return v_unwrap(unwrappable)
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -44,6 +44,11 @@ def test_Lambda():
     expected = eqx.filter_vmap(jnp.eye, axis_size=4)(3)
     assert pytest.approx(expected) == unwrap(v_diag)
 
+    # Test works when double vmapped
+    v_diag = eqx.filter_vmap(eqx.filter_vmap(Lambda))(jnp.diag, jnp.ones((5, 4, 3)))
+    expected = eqx.filter_vmap(eqx.filter_vmap(jnp.eye, axis_size=4), axis_size=5)(3)
+    assert pytest.approx(expected) == unwrap(v_diag)
+
 
 def test_NonTrainable():
     dist = Normal()

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -49,6 +49,12 @@ def test_Lambda():
     expected = eqx.filter_vmap(eqx.filter_vmap(jnp.eye, axis_size=4), axis_size=5)(3)
     assert pytest.approx(expected) == unwrap(v_diag)
 
+    # Test works when no arrays present (in which case axis_size is relied on)
+    unwrappable = eqx.filter_vmap(eqx.filter_vmap(Lambda, axis_size=2), axis_size=3)(
+        lambda: jnp.zeros(())
+    )
+    assert pytest.approx(unwrap(unwrappable)) == jnp.zeros((3, 2))
+
 
 def test_NonTrainable():
     dist = Normal()


### PR DESCRIPTION
Some wrappers use a dummy scalar array to detect vmapped initialization. These were floats, which in some cases is annoying, for example they would be filtered alongside trainable parameters (although their gradient would be zero). I have changed these arrays to integers for now. Fixed a minor bug where if unwrap was called on an object created with a vmapped init, and the ``AbstractUnwrappable`` contained no arrays to vectorize over, then the dimensions from the dummy were inferred in the wrong order.