### PR TITLE
Update wrappers

### DIFF
--- a/flowjax/train/variational_fit.py
+++ b/flowjax/train/variational_fit.py
@@ -61,7 +61,7 @@ def fit_to_variational_target(
         params, opt_state, loss = step(
             params,
             static,
-            key,
+            key=key,
             optimizer=optimizer,
             opt_state=opt_state,
             loss_fn=loss_fn,

--- a/flowjax/utils.py
+++ b/flowjax/utils.py
@@ -10,6 +10,18 @@ from jaxtyping import Array, ArrayLike
 import flowjax
 
 
+def inv_softplus(x: ArrayLike) -> Array:
+    """The inverse of the softplus function, checking for positive inputs."""
+    x = eqx.error_if(
+        x,
+        x < 0,
+        "Expected positive inputs to inv_softplus. If you are trying to use a negative "
+        "scale parameter, consider constructing with positive scales and modifying the "
+        "scale attribute post-construction, e.g., using eqx.tree_at.",
+    )
+    return jnp.log(-jnp.expm1(-x)) + x
+
+
 def merge_cond_shapes(shapes: Sequence[tuple[int, ...] | None]):
     """Merges shapes (tuples of ints or None) used in bijections and distributions.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = { file = "LICENSE" }
 name = "flowjax"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "13.1.1"
+version = "14.0.0"
 
 [project.urls]
 repository = "https://github.com/danielward27/flowjax"

--- a/tests/test_bijections/test_masked_autoregressive.py
+++ b/tests/test_bijections/test_masked_autoregressive.py
@@ -15,9 +15,8 @@ def test_masked_autoregressive_mlp():
 
     # Extract masks before unwrapping
     mlp = masked_autoregressive_mlp(in_ranks, hidden_ranks, out_ranks, depth=3, key=key)
-    masks = [layer.weight.cond for layer in mlp.layers]
-
     mlp = unwrap(mlp)
+    masks = [layer.weight != 0 for layer in mlp.layers]
     x = jnp.ones(in_size)
     y = mlp(x)
     assert y.shape == out_ranks.shape

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -37,6 +37,14 @@ def test_Parameterize():
     assert pytest.approx(unwrap(unwrappable)) == jnp.zeros((3, 2))
 
 
+def test_nested_Parameterized():
+    param = Parameterize(
+        jnp.square,
+        Parameterize(jnp.square, Parameterize(jnp.square, 2)),
+    )
+    assert unwrap(param) == jnp.square(jnp.square(jnp.square(2)))
+
+
 def test_NonTrainable_and_non_trainable():
     dist1 = eqx.tree_at(lambda dist: dist.bijection, Normal(), replace_fn=NonTrainable)
     dist2 = non_trainable(Normal())

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -4,56 +4,36 @@ import jax.numpy as jnp
 import jax.random as jr
 import pytest
 
-from flowjax.bijections import Exp, Scale
 from flowjax.distributions import Normal
 from flowjax.wrappers import (
-    BijectionReparam,
-    Lambda,
     NonTrainable,
+    Parameterize,
     WeightNormalization,
     non_trainable,
     unwrap,
 )
 
 
-def test_BijectionReparam():
-
-    with pytest.raises(eqx.EquinoxRuntimeError, match="Exp"):
-        BijectionReparam(-jnp.ones(3), Exp())
-
-    param = jnp.array([jnp.inf, 1, 2])
-    wrapped = BijectionReparam(param, Exp())
-    assert pytest.approx(unwrap(wrapped)) == param
-    assert pytest.approx(wrapped.arr) == jnp.log(param)
-
-    # Test with vmapped constructor
-
-    def _get_param(arr):
-        return BijectionReparam(arr, Scale(jnp.full(3, fill_value=2)))
-
-    init_param = jnp.ones((1, 2, 3))
-    param = eqx.filter_vmap(eqx.filter_vmap(_get_param))(init_param)
-    assert pytest.approx(init_param) == unwrap(param)
-
-
-def test_Lambda():
-    diag = Lambda(jnp.diag, jnp.ones(3))
+def test_Parameterize():
+    diag = Parameterize(jnp.diag, jnp.ones(3))
     assert pytest.approx(jnp.eye(3)) == unwrap(diag)
 
     # Test works when vmapped (note diag does not follow standard vectorization rules)
-    v_diag = eqx.filter_vmap(Lambda)(jnp.diag, jnp.ones((4, 3)))
+    v_diag = eqx.filter_vmap(Parameterize)(jnp.diag, jnp.ones((4, 3)))
     expected = eqx.filter_vmap(jnp.eye, axis_size=4)(3)
     assert pytest.approx(expected) == unwrap(v_diag)
 
     # Test works when double vmapped
-    v_diag = eqx.filter_vmap(eqx.filter_vmap(Lambda))(jnp.diag, jnp.ones((5, 4, 3)))
+    v_diag = eqx.filter_vmap(eqx.filter_vmap(Parameterize))(
+        jnp.diag, jnp.ones((5, 4, 3))
+    )
     expected = eqx.filter_vmap(eqx.filter_vmap(jnp.eye, axis_size=4), axis_size=5)(3)
     assert pytest.approx(expected) == unwrap(v_diag)
 
     # Test works when no arrays present (in which case axis_size is relied on)
-    unwrappable = eqx.filter_vmap(eqx.filter_vmap(Lambda, axis_size=2), axis_size=3)(
-        lambda: jnp.zeros(())
-    )
+    unwrappable = eqx.filter_vmap(
+        eqx.filter_vmap(Parameterize, axis_size=2), axis_size=3
+    )(lambda: jnp.zeros(()))
     assert pytest.approx(unwrap(unwrappable)) == jnp.zeros((3, 2))
 
 


### PR DESCRIPTION
This introduces a breaking change to reparameterizations.

Breaking changes:
- ``flowjax.wrappers.Lambda`` has been renamed to  ``flowjax.wrappers.Parameterize``
- ``flowjax.wrappers.BijectionReparam`` has been removed.
- ``flowjax.wrappers.Where`` has been removed.

Reasons for breaking change:
1. ``Lambda`` was renamed to ``Parameterize`` because ``Lambda`` is uninformative.
2. ``Parameterize`` is relatively simple, and flexible enough to cover the  common uses of ``BijectionReparam`` and ``Where`` (see below). 
3. Before, there was dependencies between the wrappers module, and the bijections, and vice verse (due to ``BijectionReparam``) which made it challenging to avoid circular dependencies. The removal of ``BijectionReparam`` eliminates this issue.

Transitioning:
- Replace ``Lambda`` with ``Parameterize``.
- Instead of e.g. ``BijectionReparam(scale, SoftPlus())``, we can use  ``Parameterize(softplus, inv_softplus(scale))``, using ``jax.nn.softplus`` and ``flowjax.utils.inv_softplus``.
- Instead of e.g. creating  mask with ``Where(mask, weight, 0)``, we can use ``Parameterize(jnp.where, mask, weight, 0)``.

Apologies for any inconvenience and let me know if you have any specific use cases that this causes any issues for.