### PR TITLE
Doc: clarify why constrained flows are needed.

### DIFF
--- a/docs/examples/constrained.ipynb
+++ b/docs/examples/constrained.ipynb
@@ -5,7 +5,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "### Bounded flows\n",
+                "### Flows with Constrained Parameters\n",
                 "\n",
                 "Constraining the support of a distribution explicitly can improve the accuracy of models. By doing so, we 1) prevent \"leakage\", where the model assigns mass to regions outside the support, 2) guarantee valid samples for downstream applications, and 3) add inductive bias that often makes the target easier to learn.\n",
                 "\n",
@@ -17,7 +17,8 @@
                 "\n",
                 "As an example, we'll learn a two-dimensional beta distribution with parameters $\\alpha=0.4$ and $\\beta=0.4$, using samples from the distribution, such that the ground truth model is\n",
                 "\n",
-                "$$x_i \\sim \\text{Beta}(\\alpha,\\ \\beta), \\text{ for } i \\text{ in } 1,2.$$\n"
+                "$$x_i \\sim \\text{Beta}(\\alpha,\\ \\beta), \\text{ for } i \\text{ in } 1,2.$$\n",
+                "The support of the $\\text{Beta}$ distribution is $\\[0, 1]$. Although the $\\text{Beta}$ distribution automatically respects this constraint, we need to explicitly ensure our flow does as well.\n"
             ]
         },
         {


### PR DESCRIPTION
Clarify why constrained flows are needed.

In my opinion, this example does not sufficiently motivate why constrained flows are needed. This makes it confusing for a new user, especially since working examples are how they often learn.

To remedy this, the example now explicitly mentions the support of the beta distribution and how we need to ensure our flow respects it. 

Also rename file and change title to use the more common "constrained" transform instead of "bounded" transform. See https://mc-stan.org/docs/reference-manual/transforms.html.