### PR TITLE
No need for static

### DIFF
--- a/flowjax/train/train_utils.py
+++ b/flowjax/train/train_utils.py
@@ -14,7 +14,6 @@ from jaxtyping import Array, PRNGKeyArray, PyTree, Scalar, Shaped
 @eqx.filter_jit
 def step(
     params: PyTree,
-    static: PyTree,
     *args,
     optimizer: optax.GradientTransformation,
     opt_state: PyTree,
@@ -25,8 +24,8 @@ def step(
 
     Args:
         params: Parameters for the model
-        static: Static components of the model.
-        *args: Arguments passed to the loss function.
+        *args: Arguments passed to the loss function (often the static components
+            of the model).
         optimizer: Optax optimizer.
         opt_state: Optimizer state.
         loss_fn: The loss function. This should take params and static as the first two
@@ -38,7 +37,6 @@ def step(
     """
     loss_val, grads = eqx.filter_value_and_grad(loss_fn)(
         params,
-        static,
         *args,
         **kwargs,
     )


### PR DESCRIPTION
The static component can be passed within args. This gives a little more flexibility to users for loss function signature with step (e.g. can ``functools.partial`` out static in loss).