### PR TITLE
Reduce coupling

### DIFF
--- a/flowjax/bijections/coupling.py
+++ b/flowjax/bijections/coupling.py
@@ -10,6 +10,7 @@ import jax.nn as jnn
 import jax.numpy as jnp
 from jaxtyping import PRNGKeyArray
 
+from flowjax import wrappers
 from flowjax.bijections.bijection import AbstractBijection
 from flowjax.bijections.jax_transforms import Vmap
 from flowjax.utils import Array, get_ravelled_pytree_constructor
@@ -55,7 +56,11 @@ class Coupling(AbstractBijection):
                 "Only unconditional transformers with shape () are supported.",
             )
 
-        constructor, num_params = get_ravelled_pytree_constructor(transformer)
+        constructor, num_params = get_ravelled_pytree_constructor(
+            transformer,
+            filter_spec=eqx.is_inexact_array,
+            is_leaf=lambda leaf: isinstance(leaf, wrappers.NonTrainable),
+        )
 
         self.transformer_constructor = constructor
         self.untransformed_dim = untransformed_dim

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = { file = "LICENSE" }
 name = "flowjax"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "15.1.0"
+version = "16.0.0"
 
 [project.urls]
 repository = "https://github.com/danielward27/flowjax"


### PR DESCRIPTION
Small change so that utils.py does not depend on wrappers.py.

Calls to ``get_ravelled_pytree_constructor`` will now need to explicitly pass the *args and **kwargs for partitioning parameters (usually setting ``is_leaf=lambda leaf: isinstance(leaf, wrappers.NonTrainable)``.