### PR TITLE
Add inverse_and_gradient method to bijection

### DIFF
--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -56,6 +56,17 @@ class Affine(AbstractBijection):
     def inverse_and_log_det(self, y, condition=None):
         return (y - self.loc) / self.scale, -jnp.log(jnp.abs(self.scale)).sum()
 
+    def inverse_gradient_and_val(
+        self,
+        y: Array,
+        y_grad: Array,
+        y_logp: Array,
+        condition: ArrayLike | None = None,
+    ) -> tuple[Array, Array, Array]:
+        x, logdet = self.inverse_and_log_det(y)
+        x_grad = y_grad * self.scale
+        return (x, x_grad, y_logp - logdet)
+
 
 class Loc(AbstractBijection):
     r"""Location transformation :math:`y = a \cdot x + b`.

--- a/flowjax/bijections/affine.py
+++ b/flowjax/bijections/affine.py
@@ -238,10 +238,10 @@ class AdditiveCondition(AbstractBijection):
         return x + self.module(condition)
 
     def transform_and_log_det(self, x, condition=None):
-        return self.transform(x, condition), jnp.array(0)
+        return self.transform(x, condition), jnp.zeros(())
 
     def inverse(self, y, condition=None):
         return y - self.module(condition)
 
     def inverse_and_log_det(self, y, condition=None):
-        return self.inverse(y, condition), jnp.array(0)
+        return self.inverse(y, condition), jnp.zeros(())

--- a/flowjax/bijections/bijection.py
+++ b/flowjax/bijections/bijection.py
@@ -230,10 +230,12 @@ class AbstractBijection(eqx.Module):
             x_grad: The gradient of the log density at `x`.
             x_logp: The log density on the untransformed space at `x`.
         """
-        x, logdet = self.inverse_and_log_det(y, condition)
-        _, pull_grad_fn = jax.vjp(lambda x: self.transform_and_log_det(x, condition), x)
+        x = self.inverse(y, condition)
+        (_, fwd_log_det), pull_grad_fn = jax.vjp(
+            lambda x: self.transform_and_log_det(x, condition), x
+        )
         (x_grad,) = pull_grad_fn((y_grad, jnp.ones(())))
-        return (x, x_grad, y_logp - logdet)
+        return (x, x_grad, y_logp + fwd_log_det)
 
     @property
     def _vectorize(self):

--- a/flowjax/bijections/chain.py
+++ b/flowjax/bijections/chain.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 
 from paramax import AbstractUnwrappable, unwrap
 from jax import Array
+import jax.numpy as jnp
 
 from flowjax.bijections.bijection import AbstractBijection
 from flowjax.utils import check_shapes_match, merge_cond_shapes
@@ -33,13 +34,15 @@ class Chain(AbstractBijection):
         self.cond_shape = merge_cond_shapes([unwrap(b).cond_shape for b in unwrapped])
         self.bijections = tuple(bijections)
 
-    def transform(self, x, condition=None):
+    def transform(self, x: Array, condition: Array | None = None) -> Array:
         for bijection in self.bijections:
             x = bijection.transform(x, condition)
         return x
 
-    def transform_and_log_det(self, x, condition=None):
-        log_abs_det_jac = 0
+    def transform_and_log_det(
+        self, x: Array, condition: Array | None = None
+    ) -> tuple[Array, Array]:
+        log_abs_det_jac = jnp.zeros(())
         for bijection in self.bijections:
             x, log_abs_det_jac_i = bijection.transform_and_log_det(x, condition)
             log_abs_det_jac += log_abs_det_jac_i.sum()
@@ -50,8 +53,10 @@ class Chain(AbstractBijection):
             y = bijection.inverse(y, condition)
         return y
 
-    def inverse_and_log_det(self, y, condition=None):
-        log_abs_det_jac = 0
+    def inverse_and_log_det(
+        self, y: Array, condition: Array | None = None
+    ) -> tuple[Array, Array]:
+        log_abs_det_jac = jnp.zeros(())
         for bijection in reversed(self.bijections):
             y, log_abs_det_jac_i = bijection.inverse_and_log_det(y, condition)
             log_abs_det_jac += log_abs_det_jac_i.sum()

--- a/flowjax/bijections/chain.py
+++ b/flowjax/bijections/chain.py
@@ -3,6 +3,7 @@
 from collections.abc import Sequence
 
 from paramax import AbstractUnwrappable, unwrap
+from jax import Array
 
 from flowjax.bijections.bijection import AbstractBijection
 from flowjax.utils import check_shapes_match, merge_cond_shapes
@@ -55,6 +56,19 @@ class Chain(AbstractBijection):
             y, log_abs_det_jac_i = bijection.inverse_and_log_det(y, condition)
             log_abs_det_jac += log_abs_det_jac_i.sum()
         return y, log_abs_det_jac
+
+    def inverse_gradient_and_val(
+        self,
+        y: Array,
+        y_grad: Array,
+        y_logp: Array,
+        condition: Array | None = None,
+    ) -> tuple[Array, Array, Array]:
+        for bijection in reversed(self.bijections):
+            y, y_grad, y_logp = bijection.inverse_gradient_and_val(
+                y, y_grad, y_logp, condition
+            )
+        return y, y_grad, y_logp
 
     def __getitem__(self, i: int | slice) -> AbstractBijection:
         if isinstance(i, int):

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -88,13 +88,24 @@ class Permute(AbstractBijection):
         return x[self.permutation]
 
     def transform_and_log_det(self, x, condition=None):
-        return x[self.permutation], jnp.array(0)
+        return x[self.permutation], jnp.array(0.0)
 
     def inverse(self, y, condition=None):
         return y[self.inverse_permutation]
 
     def inverse_and_log_det(self, y, condition=None):
-        return y[self.inverse_permutation], jnp.array(0)
+        return y[self.inverse_permutation], jnp.array(0.0)
+
+    def inverse_gradient_and_val(
+        self,
+        y: Array,
+        y_grad: Array,
+        y_logp: Array,
+        condition: Array | None = None,
+    ) -> tuple[Array, Array, Array]:
+        x = y[self.inverse_permutation]
+        x_grad = y_grad[self.inverse_permutation]
+        return x, x_grad, y_logp
 
 
 class Flip(AbstractBijection):

--- a/flowjax/bijections/utils.py
+++ b/flowjax/bijections/utils.py
@@ -118,17 +118,21 @@ class Flip(AbstractBijection):
     shape: tuple[int, ...] = ()
     cond_shape: ClassVar[None] = None
 
-    def transform(self, x, condition=None):
+    def transform(self, x: Array, condition: Array | None = None) -> Array:
         return jnp.flip(x)
 
-    def transform_and_log_det(self, x, condition=None):
-        return jnp.flip(x), jnp.array(0)
+    def transform_and_log_det(
+        self, x: Array, condition: Array | None = None
+    ) -> tuple[Array, Array]:
+        return jnp.flip(x), jnp.zeros(())
 
-    def inverse(self, y, condition=None):
+    def inverse(self, y: Array, condition: Array | None = None) -> Array:
         return jnp.flip(y)
 
-    def inverse_and_log_det(self, y, condition=None):
-        return jnp.flip(y), jnp.array(0)
+    def inverse_and_log_det(
+        self, y: Array, condition: Array | None = None
+    ) -> tuple[Array, Array]:
+        return jnp.flip(y), jnp.zeros(())
 
 
 class Partial(AbstractBijection):

--- a/tests/test_bijections/test_bijections.py
+++ b/tests/test_bijections/test_bijections.py
@@ -1,4 +1,5 @@
 "General tests for bijections (including transformers)."
+
 from abc import abstractmethod
 
 import equinox as eqx
@@ -283,6 +284,9 @@ def test_inverse_gradient_and_val(bijection_name):
     bijection = bijections[bijection_name]()
     shape = bijection.shape if bijection.shape is not None else (DIM,)
     y = jr.normal(jr.PRNGKey(0), shape)
+
+    if type(bijection) in POSITIVE_DOMAIN:
+        y = jnp.abs(y)
 
     if bijection.cond_shape is not None:
         cond = jr.normal(jr.PRNGKey(0), bijection.cond_shape)


### PR DESCRIPTION
This includes an extra method to bijections that I use for a project of mine. I'm not sure if this is of enough general interest to include into the library, but including it would certainly make my life easier, and there might be other use cases around.

If there is a known density defined on the transformed space of some bijection, we can compute the logp, and the gradient of that logp on this transformed space. In the code I call those `y` (the position), `y_grad` (the gradient of the log density at `y`) and `y_logp` (the log-density at `y`).

We can then compute these quantities on the untransformed space, using some autodiff where we need to take into account the jacobian determinant.

The PR contains a general implementation in the `AbstractBijection` class. The code that this generates is not always the best however, so for some bijections I also implement special cases (`Affine`, `Chain`, `Permutation` and `Coupling`).

The special implementations are tested against the general implementation, and the general implementation is tested agains analytical solutions for `Affine` and `Exp` transformations.