### PR TITLE
Avoid signature help including abstractvar

### DIFF
--- a/flowjax/distributions.py
+++ b/flowjax/distributions.py
@@ -209,7 +209,6 @@ class AbstractDistribution(eqx.Module):
         sample_shape: tuple[int, ...],
         condition,
     ):
-
         if not dtypes.issubdtype(key.dtype, dtypes.prng_key):
             raise TypeError("New-style typed JAX PRNG keys required.")
 
@@ -339,6 +338,7 @@ class Transformed(AbstractTransformed):
             >>> bijection = Affine(1)
             >>> transformed = Transformed(normal, bijection)
     """
+
     base_dist: AbstractDistribution
     bijection: AbstractBijection
 
@@ -346,7 +346,6 @@ class Transformed(AbstractTransformed):
     def __init__(self, base_dist: AbstractDistribution, bijection: AbstractBijection):
         self.base_dist = base_dist
         self.bijection = bijection
-
 
 
 class AbstractLocScaleDistribution(AbstractTransformed):


### PR DESCRIPTION
If using an equinox ``AbstractVar`` implemented as a property, on an equinox ``Module`` with the default init, the signature hint wrongly includes the abstract variables, creating a confusing experience.

This pull request just changes from using properties to attributes in a few cases to avoid this issue.