### PR TITLE
Fix issue with isinstance with ArrayLike

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.x"]
+
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/flowjax/utils.py
+++ b/flowjax/utils.py
@@ -103,7 +103,7 @@ def arraylike_to_array(
         err_name: Name of the input in the error message. Defaults to "input".
         **kwargs: Keyword arguments passed to jnp.asarray.
     """
-    if not isinstance(arr, ArrayLike):
+    if not eqx.is_array_like(arr):
         raise TypeError(
             f"Expected {err_name} to be arraylike; got {type(arr).__name__}.",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 dependencies = [
-    "jax>=0.4.16",
-    "equinox>=0.10",
+    "jax>=0.7.0",
+    "equinox>=0.11",
     "jaxtyping",
     "tqdm",
     "optax",
@@ -23,8 +23,8 @@ keywords = ["jax", "neural-networks", "equinox"]
 license = { file = "LICENSE" }
 name = "flowjax"
 readme = "README.md"
-requires-python = ">=3.10"
-version = "19.0.0"
+requires-python = ">=3.11"
+version = "19.1.0"
 
 [project.urls]
 repository = "https://github.com/danielward27/flowjax"
@@ -35,7 +35,7 @@ dev = [
     "pytest",
     "beartype",
     "ruff",
-    "sphinx <8.2",              # TODO due to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/523
+    "sphinx",
     "sphinx-book-theme",
     "sphinx-copybutton",
     "sphinx-autodoc-typehints",


### PR DESCRIPTION
Restricts python version to >3.11 and fixes https://github.com/danielward27/flowjax/issues/230. The tests now run on 3.11 and 3.x to try and avoid further python version related issues. Whilst unfortunate to restrict to >3.11:
- Recent numpyro versions restricts to python > 3.11, and we need a recent numypro version (>=0.20.0), because of recent breaking changes to their distributions, and I will only support the more up to date version.
- This is slightly annoying as numpyro is an optional dependency, but to run all tests on 3.11 and 3.x (some of which include numpyro), this is the easiest (albeit slightly lazy) solution.

