### PR TITLE
Fix: resolve NaN gradients in RQS out-of-bounds inverse pass

### DIFF
--- a/flowjax/bijections/rational_quadratic_spline.py
+++ b/flowjax/bijections/rational_quadratic_spline.py
@@ -66,9 +66,10 @@ class RationalQuadraticSpline(AbstractBijection):
             x >= jnp.array(self.interval[0]),
             x <= jnp.array(self.interval[1]),
         )
-        k = jnp.searchsorted(x_pos, x) - 1  # k is bin number
+        x_clipped = jnp.clip(x, self.interval[0], self.interval[1])
+        k = jnp.searchsorted(x_pos, x_clipped) - 1  # k is bin number
         k = jnp.clip(k, min=0, max=len(x_pos) - 2)
-        xi = (x - x_pos[k]) / (x_pos[k + 1] - x_pos[k])
+        xi = (x_clipped - x_pos[k]) / (x_pos[k + 1] - x_pos[k])
         sk = (y_pos[k + 1] - y_pos[k]) / (x_pos[k + 1] - x_pos[k])
         dk, dk1, yk, yk1 = derivatives[k], derivatives[k + 1], y_pos[k], y_pos[k + 1]
         num = (yk1 - yk) * (sk * xi**2 + dk * xi * (1 - xi))
@@ -94,14 +95,15 @@ class RationalQuadraticSpline(AbstractBijection):
             y >= jnp.array(self.interval[0]),
             y <= jnp.array(self.interval[1]),
         )
-        k = jnp.searchsorted(y_pos, y) - 1
+        y_clipped = jnp.clip(y, self.interval[0], self.interval[1])
+        k = jnp.searchsorted(y_pos, y_clipped) - 1
         k = jnp.clip(k, min=0, max=len(x_pos) - 2)
         xk, xk1, yk, yk1 = x_pos[k], x_pos[k + 1], y_pos[k], y_pos[k + 1]
         sk = (yk1 - yk) / (xk1 - xk)
-        y_delta_s_term = (y - yk) * (derivatives[k + 1] + derivatives[k] - 2 * sk)
+        y_delta_s_term = (y_clipped - yk) * (derivatives[k + 1] + derivatives[k] - 2 * sk)
         a = (yk1 - yk) * (sk - derivatives[k]) + y_delta_s_term
         b = (yk1 - yk) * derivatives[k] - y_delta_s_term
-        c = -sk * (y - yk)
+        c = -sk * (y_clipped - yk)
         sqrt_term = jnp.sqrt(b**2 - 4 * a * c)
         xi = (2 * c) / (-b - sqrt_term)
         x = xi * (xk1 - xk) + xk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ license = { file = "LICENSE" }
 name = "flowjax"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "19.1.0"
+version = "19.1.1"
 
 [project.urls]
 repository = "https://github.com/danielward27/flowjax"

--- a/tests/test_bijections/test_rational_quadratic_spline.py
+++ b/tests/test_bijections/test_rational_quadratic_spline.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import pytest
 from jax import vmap
-from jax.tree_util import tree_map, tree_leaves
+from jax.tree_util import tree_leaves, tree_map
 
 from flowjax.bijections import RationalQuadraticSpline
 
@@ -37,46 +37,24 @@ def test_RationalQuadraticSpline_init(interval):
     y = vmap(spline.transform)(x)
     assert pytest.approx(x, abs=1e-6) == y
 
-@pytest.mark.parametrize("direction", ["forward", "inverse"])
-def test_RationalQuadraticSpline_out_of_bounds_grad_nan(direction):
-    """Checks that gradients do not contain NaNs when evaluating the forward 
-    and inverse passes on out-of-bounds inputs."""
-    
-    # 1. Initialize RQS
+
+def test_RationalQuadraticSpline_out_of_bounds_grad_nan():
+    """Checks that gradients do not contain NaNs for out of interval inputs."""
+    key = jr.key(1)
     spline = RationalQuadraticSpline(knots=4, interval=1.0)
-
-    # 2. Partition and add truly random noise to simulate a "trained" state
-    params, static = eqx.partition(spline, eqx.is_inexact_array)
-    key = jr.key(42)
-    
-    def add_noise(x):
-        nonlocal key
-        if x is not None:
-            key, subkey = jr.split(key)
-            return x + jr.normal(subkey, x.shape) * 1.5
-        return x
-        
-    params_noisy = tree_map(add_noise, params)
-    spline_trained = eqx.combine(params_noisy, static)
-
-    # 3. Provide an out-of-bounds input (interval is 1.0, so 50.0 is way out)
-    val = jnp.array(50.0)
-
-    # 4. Define a dummy loss evaluating the requested direction
-    def loss(model, v):
-        if direction == "forward":
-            out, _ = model.transform_and_log_det(v)
-        else:
-            out, _ = model.inverse_and_log_det(v)
-        return out.sum()
-
-    # 5. Compute gradients
-    _, grad = eqx.filter_value_and_grad(loss)(spline_trained, val)
-
-    # 6. Check for NaNs
-    nan_found = any(
-        jnp.any(jnp.isnan(leaf)) 
-        for leaf in tree_leaves(grad) if eqx.is_array(leaf)
+    spline = tree_map(  # Not identity
+        lambda x: x + jr.normal(key, x.shape) * 1.5 if eqx.is_inexact_array(x) else x,
+        spline,
     )
-    
-    assert not nan_found, f"NaNs detected in gradients for out-of-bounds {direction} pass"
+    val = jnp.array(50.0)  # Out of bounds
+    forward_grad = eqx.filter_grad(lambda m, v: m.transform_and_log_det(v)[0].sum())(
+        spline, val
+    )
+    inverse_grad = eqx.filter_grad(lambda m, v: m.inverse_and_log_det(v)[0].sum())(
+        spline, val
+    )
+
+    for grad in (forward_grad, inverse_grad):
+        assert not any(
+            jnp.any(jnp.isnan(leaf)) for leaf in tree_leaves(grad) if eqx.is_array(leaf)
+        ), "NaNs detected in gradients for out-of-bounds pass"

--- a/tests/test_bijections/test_rational_quadratic_spline.py
+++ b/tests/test_bijections/test_rational_quadratic_spline.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import pytest
 from jax import vmap
-from jax.tree_util import tree_map
+from jax.tree_util import tree_map, tree_leaves
 
 from flowjax.bijections import RationalQuadraticSpline
 
@@ -36,3 +36,47 @@ def test_RationalQuadraticSpline_init(interval):
     spline = RationalQuadraticSpline(knots=10, interval=interval)
     y = vmap(spline.transform)(x)
     assert pytest.approx(x, abs=1e-6) == y
+
+@pytest.mark.parametrize("direction", ["forward", "inverse"])
+def test_RationalQuadraticSpline_out_of_bounds_grad_nan(direction):
+    """Checks that gradients do not contain NaNs when evaluating the forward 
+    and inverse passes on out-of-bounds inputs."""
+    
+    # 1. Initialize RQS
+    spline = RationalQuadraticSpline(knots=4, interval=1.0)
+
+    # 2. Partition and add truly random noise to simulate a "trained" state
+    params, static = eqx.partition(spline, eqx.is_inexact_array)
+    key = jr.key(42)
+    
+    def add_noise(x):
+        nonlocal key
+        if x is not None:
+            key, subkey = jr.split(key)
+            return x + jr.normal(subkey, x.shape) * 1.5
+        return x
+        
+    params_noisy = tree_map(add_noise, params)
+    spline_trained = eqx.combine(params_noisy, static)
+
+    # 3. Provide an out-of-bounds input (interval is 1.0, so 50.0 is way out)
+    val = jnp.array(50.0)
+
+    # 4. Define a dummy loss evaluating the requested direction
+    def loss(model, v):
+        if direction == "forward":
+            out, _ = model.transform_and_log_det(v)
+        else:
+            out, _ = model.inverse_and_log_det(v)
+        return out.sum()
+
+    # 5. Compute gradients
+    _, grad = eqx.filter_value_and_grad(loss)(spline_trained, val)
+
+    # 6. Check for NaNs
+    nan_found = any(
+        jnp.any(jnp.isnan(leaf)) 
+        for leaf in tree_leaves(grad) if eqx.is_array(leaf)
+    )
+    
+    assert not nan_found, f"NaNs detected in gradients for out-of-bounds {direction} pass"


### PR DESCRIPTION
# Fix: Resolve NaN gradients for out-of-bounds inputs in RationalQuadraticSpline

**Closes #239**

### Description
This PR resolves a regression introduced in `v18.0.0` where evaluating the `RationalQuadraticSpline` on out-of-bounds inputs caused `NaN`s in the reverse-mode gradients for the inverse pass, poisoning the gradients for the entire batch.

**The Issue:**
Although the final output safely defaults to the identity mapping via `jnp.where` for out-of-bounds inputs, the mathematical operations were still being evaluated on the raw, unclipped variables. In the **inverse pass**, this caused `jnp.sqrt` to evaluate a negative discriminant for out-of-bounds data. This resulted in `NaN` values that propagated through the unselected branches during backpropagation.

**The Fix:**
* **Inverse Pass (The Bug):** Restored numerical safety by applying `jnp.clip` to `y` to bound it to `self.interval` strictly *before* computing the bin index `k` and intermediate variables. The original, unclipped `y` is preserved solely for the final `jnp.where` fallback.
* **Forward Pass (Safeguard):** Proactively applied the exact same clipping logic to `x` in `transform_and_log_det`. While the forward pass was not strictly producing `NaN`s (as the polynomial math happens to avoid undefined domains), applying this ensures architectural consistency and protects against potential overflows.

**Testing:**
* Added a new parametrized unit test `test_RationalQuadraticSpline_out_of_bounds_grad_nan` in `test_rational_quadratic_spline.py`.
* The test simulates a noisy initialized state and evaluates both the `forward` and `inverse` passes on out-of-bounds inputs (`50.0`), asserting that no `NaN`s exist in the resulting gradient leaves. Both passes test cleanly.